### PR TITLE
Fix Modal detach mode and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ modal:
 uv run leap-finetune job_configs/sft_example_modal.yaml
 ```
 
-That's it. The CLI will:
+That's it. In attached mode (`detach: false`), the CLI will:
 
 1. Build the container image (~5 min on first run, cached after that)
 2. Auto-create a `huggingface-secret` on Modal from your local HF token
@@ -130,7 +130,14 @@ modal volume ls leap-finetune                                        # list save
 modal volume get leap-finetune <checkpoint-name> ./local-outputs     # download to local
 ```
 
-**Detached mode:** Set `detach: true` in the modal config to submit and disconnect. Monitor with `modal app logs leap-finetune`.
+**Detached mode:** Set `detach: true` in the modal config to submit and disconnect. The CLI prints the Modal app ID for that run, plus commands to monitor or stop it:
+
+```bash
+modal app logs ap-...
+modal app stop ap-...
+```
+
+Detached runs are ephemeral Modal apps, so use the printed `ap-...` app ID rather than the `app_name` value from your config when viewing logs.
 
 See [`job_configs/sft_example_modal.yaml`](./job_configs/sft_example_modal.yaml) for all available options.
 

--- a/src/leap_finetune/backends/modal_backend.py
+++ b/src/leap_finetune/backends/modal_backend.py
@@ -1,9 +1,5 @@
-import os
 import pathlib
-import subprocess
 import sys
-import tempfile
-import textwrap
 
 import yaml
 
@@ -76,6 +72,8 @@ def _get_local_hf_token() -> str | None:
 
 
 def _ensure_modal_secret(token: str) -> None:
+    import subprocess
+
     result = subprocess.run(
         ["modal", "secret", "list", "--json"], capture_output=True, text=True
     )
@@ -138,6 +136,8 @@ def _print_config_summary(config_dict: dict, modal_cfg: dict) -> None:
 
 
 def _submit(config_dict: dict, modal_cfg: dict) -> None:
+    from contextlib import nullcontext
+
     import modal
 
     detach = modal_cfg.get("detach", False)
@@ -155,45 +155,14 @@ def _submit(config_dict: dict, modal_cfg: dict) -> None:
         print(f"\nTrackio dashboard: https://huggingface.co/spaces/{space_id}\n")
 
     config_str = yaml.dump(config_dict)
-    app_name = modal_cfg.get("app_name", "leap-finetune")
+
+    app = modal.App(modal_cfg.get("app_name", "leap-finetune"))
     image = _build_image(modal_cfg)
     volume = modal.Volume.from_name(
         modal_cfg.get("output_volume", "leap-finetune"),
         create_if_missing=True,
     )
     secrets = [modal.Secret.from_name(s) for s in (modal_cfg.get("secrets") or [])]
-
-    if detach:
-        _submit_detached(app_name, image, output_dir, volume, secrets, modal_cfg, config_str)
-    else:
-        _submit_attached(app_name, image, output_dir, volume, secrets, modal_cfg, config_str)
-
-
-def _run_train(cfg: str, output_dir: str) -> None:
-    import tempfile
-
-    for prefix in ("leap_finetune", "huggingface_hub", "datasets", "fsspec"):
-        for mod_name in [m for m in sys.modules if m.startswith(prefix)]:
-            del sys.modules[mod_name]
-
-    os.environ["LEAP_FINETUNE_DIR"] = "/app"
-    os.environ["OUTPUT_DIR"] = output_dir
-    os.environ.pop("HF_HUB_OFFLINE", None)
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        f.write(cfg)
-        tmp_path = f.name
-
-    sys.argv = ["leap-finetune", tmp_path]
-    from leap_finetune import main as leap_main
-
-    leap_main()
-
-
-def _submit_attached(app_name, image, output_dir, volume, secrets, modal_cfg, config_str):
-    import modal
-
-    app = modal.App(app_name)
 
     @app.function(
         image=image,
@@ -204,104 +173,47 @@ def _submit_attached(app_name, image, output_dir, volume, secrets, modal_cfg, co
         serialized=True,
     )
     def train(cfg: str) -> None:
-        _run_train(cfg, output_dir)
+        import os
+        import sys
+        import tempfile
 
-    print("Waiting for container to start (image is cached after first build)...")
-    with modal.enable_output():
-        with app.run():
-            try:
-                train.remote(config_str)
-            except modal.exception.RemoteError as e:
+        for prefix in ("leap_finetune", "huggingface_hub", "datasets", "fsspec"):
+            for mod_name in [m for m in sys.modules if m.startswith(prefix)]:
+                del sys.modules[mod_name]
+
+        os.environ["LEAP_FINETUNE_DIR"] = "/app"
+        os.environ["OUTPUT_DIR"] = output_dir
+        os.environ.pop("HF_HUB_OFFLINE", None)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(cfg)
+            tmp_path = f.name
+
+        sys.argv = ["leap-finetune", tmp_path]
+        from leap_finetune import main as leap_main
+
+        leap_main()
+
+    if detach:
+        print("Submitting detached Modal job (image is cached after first build)...")
+    else:
+        print("Waiting for container to start (image is cached after first build)...")
+
+    output_context = nullcontext() if detach else modal.enable_output()
+    with output_context:
+        with app.run(detach=detach):
+            if detach:
+                call = train.spawn(config_str)
                 print(
-                    f"\nModal container exited with error after training: {e}\n"
-                    "Check the logs above — training likely completed and the\n"
-                    "error occurred during container teardown."
+                    f"Modal job submitted (detached). Function call ID: {call.object_id}"
                 )
-
-
-def _submit_detached(app_name, image, output_dir, volume, secrets, modal_cfg, config_str):
-    gpu = modal_cfg.get("gpu", "H100")
-    timeout = modal_cfg.get("timeout", 86400)
-    secret_names = modal_cfg.get("secrets") or []
-    output_volume = modal_cfg.get("output_volume", "leap-finetune")
-
-    base_image = modal_cfg.get("base_image", "nvidia/cuda:12.8.0-devel-ubuntu22.04")
-    pyproject = str(_REPO_ROOT / "pyproject.toml")
-    lockfile = str(_REPO_ROOT / "uv.lock")
-    src_dir = str(_REPO_ROOT / "src" / "leap_finetune")
-
-    script = textwrap.dedent(f"""\
-        import modal
-
-        app = modal.App("{app_name}")
-
-        image = (
-            modal.Image.from_registry("{base_image}", add_python="3.12")
-            .pip_install("uv")
-            .add_local_file("{pyproject}", remote_path="/app/pyproject.toml", copy=True)
-            .add_local_file("{lockfile}", remote_path="/app/uv.lock", copy=True)
-            .run_commands(
-                "cd /app && uv export --frozen --no-dev --no-emit-project --no-hashes"
-                " > requirements.txt"
-                " && grep -v flash-attn requirements.txt > requirements-modal.txt"
-                " && uv pip install --system -r requirements-modal.txt",
-            )
-            .add_local_dir("{src_dir}", remote_path="/app/src/leap_finetune", copy=True)
-            .env({{
-                "PYTHONPATH": "/app/src",
-                "LEAP_FINETUNE_DIR": "/app",
-                "RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE": "1",
-            }})
-        )
-
-        volume = modal.Volume.from_name("{output_volume}", create_if_missing=True)
-        secrets = [modal.Secret.from_name(s) for s in {secret_names!r}]
-
-        @app.function(
-            image=image,
-            gpu="{gpu}",
-            timeout={timeout},
-            volumes={{"{output_dir}": volume}},
-            secrets=secrets,
-            serialized=True,
-        )
-        def train(cfg: str) -> None:
-            import os, sys, tempfile
-            for prefix in ("leap_finetune", "huggingface_hub", "datasets", "fsspec"):
-                for mod_name in [m for m in sys.modules if m.startswith(prefix)]:
-                    del sys.modules[mod_name]
-            os.environ["LEAP_FINETUNE_DIR"] = "/app"
-            os.environ["OUTPUT_DIR"] = "{output_dir}"
-            os.environ.pop("HF_HUB_OFFLINE", None)
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-                f.write(cfg)
-                tmp_path = f.name
-            sys.argv = ["leap-finetune", tmp_path]
-            from leap_finetune import main as leap_main
-            leap_main()
-
-        @app.local_entrypoint()
-        def main():
-            train.remote({config_str!r})
-    """)
-
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".py", delete=False, prefix="modal-train-"
-    ) as f:
-        f.write(script)
-        script_path = f.name
-
-    print(f"Submitting detached Modal job via 'modal run --detach'...")
-    result = subprocess.run(
-        ["modal", "run", "--detach", script_path],
-    )
-    os.unlink(script_path)
-
-    if result.returncode != 0:
-        print(f"modal run --detach failed with exit code {result.returncode}")
-        sys.exit(1)
-
-    print(f"\nMonitor with: modal app logs {app_name}")
+                if app.app_id:
+                    print(f"Modal app ID: {app.app_id}")
+                    print(f"Dashboard: https://modal.com/id/{app.app_id}")
+                    print(f"Monitor with: modal app logs {app.app_id}")
+                    print(f"Stop with: modal app stop {app.app_id}")
+            else:
+                train.remote(config_str)
 
 
 # === Image build ===

--- a/src/leap_finetune/backends/modal_backend.py
+++ b/src/leap_finetune/backends/modal_backend.py
@@ -1,5 +1,9 @@
+import os
 import pathlib
+import subprocess
 import sys
+import tempfile
+import textwrap
 
 import yaml
 
@@ -72,8 +76,6 @@ def _get_local_hf_token() -> str | None:
 
 
 def _ensure_modal_secret(token: str) -> None:
-    import subprocess
-
     result = subprocess.run(
         ["modal", "secret", "list", "--json"], capture_output=True, text=True
     )
@@ -153,14 +155,45 @@ def _submit(config_dict: dict, modal_cfg: dict) -> None:
         print(f"\nTrackio dashboard: https://huggingface.co/spaces/{space_id}\n")
 
     config_str = yaml.dump(config_dict)
-
-    app = modal.App(modal_cfg.get("app_name", "leap-finetune"))
+    app_name = modal_cfg.get("app_name", "leap-finetune")
     image = _build_image(modal_cfg)
     volume = modal.Volume.from_name(
         modal_cfg.get("output_volume", "leap-finetune"),
         create_if_missing=True,
     )
     secrets = [modal.Secret.from_name(s) for s in (modal_cfg.get("secrets") or [])]
+
+    if detach:
+        _submit_detached(app_name, image, output_dir, volume, secrets, modal_cfg, config_str)
+    else:
+        _submit_attached(app_name, image, output_dir, volume, secrets, modal_cfg, config_str)
+
+
+def _run_train(cfg: str, output_dir: str) -> None:
+    import tempfile
+
+    for prefix in ("leap_finetune", "huggingface_hub", "datasets", "fsspec"):
+        for mod_name in [m for m in sys.modules if m.startswith(prefix)]:
+            del sys.modules[mod_name]
+
+    os.environ["LEAP_FINETUNE_DIR"] = "/app"
+    os.environ["OUTPUT_DIR"] = output_dir
+    os.environ.pop("HF_HUB_OFFLINE", None)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(cfg)
+        tmp_path = f.name
+
+    sys.argv = ["leap-finetune", tmp_path]
+    from leap_finetune import main as leap_main
+
+    leap_main()
+
+
+def _submit_attached(app_name, image, output_dir, volume, secrets, modal_cfg, config_str):
+    import modal
+
+    app = modal.App(app_name)
 
     @app.function(
         image=image,
@@ -171,40 +204,104 @@ def _submit(config_dict: dict, modal_cfg: dict) -> None:
         serialized=True,
     )
     def train(cfg: str) -> None:
-        import os
-        import sys
-        import tempfile
-
-        for prefix in ("leap_finetune", "huggingface_hub", "datasets", "fsspec"):
-            for mod_name in [m for m in sys.modules if m.startswith(prefix)]:
-                del sys.modules[mod_name]
-
-        os.environ["LEAP_FINETUNE_DIR"] = "/app"
-        os.environ["OUTPUT_DIR"] = output_dir
-        os.environ.pop("HF_HUB_OFFLINE", None)
-
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write(cfg)
-            tmp_path = f.name
-
-        sys.argv = ["leap-finetune", tmp_path]
-        from leap_finetune import main as leap_main
-
-        leap_main()
+        _run_train(cfg, output_dir)
 
     print("Waiting for container to start (image is cached after first build)...")
     with modal.enable_output():
         with app.run():
-            if detach:
-                call = train.spawn(config_str)
-                print(
-                    f"Modal job submitted (detached). Function call ID: {call.object_id}"
-                )
-                print(
-                    f"Monitor with: modal app logs {modal_cfg.get('app_name', 'leap-finetune')}"
-                )
-            else:
+            try:
                 train.remote(config_str)
+            except modal.exception.RemoteError as e:
+                print(
+                    f"\nModal container exited with error after training: {e}\n"
+                    "Check the logs above — training likely completed and the\n"
+                    "error occurred during container teardown."
+                )
+
+
+def _submit_detached(app_name, image, output_dir, volume, secrets, modal_cfg, config_str):
+    gpu = modal_cfg.get("gpu", "H100")
+    timeout = modal_cfg.get("timeout", 86400)
+    secret_names = modal_cfg.get("secrets") or []
+    output_volume = modal_cfg.get("output_volume", "leap-finetune")
+
+    base_image = modal_cfg.get("base_image", "nvidia/cuda:12.8.0-devel-ubuntu22.04")
+    pyproject = str(_REPO_ROOT / "pyproject.toml")
+    lockfile = str(_REPO_ROOT / "uv.lock")
+    src_dir = str(_REPO_ROOT / "src" / "leap_finetune")
+
+    script = textwrap.dedent(f"""\
+        import modal
+
+        app = modal.App("{app_name}")
+
+        image = (
+            modal.Image.from_registry("{base_image}", add_python="3.12")
+            .pip_install("uv")
+            .add_local_file("{pyproject}", remote_path="/app/pyproject.toml", copy=True)
+            .add_local_file("{lockfile}", remote_path="/app/uv.lock", copy=True)
+            .run_commands(
+                "cd /app && uv export --frozen --no-dev --no-emit-project --no-hashes"
+                " > requirements.txt"
+                " && grep -v flash-attn requirements.txt > requirements-modal.txt"
+                " && uv pip install --system -r requirements-modal.txt",
+            )
+            .add_local_dir("{src_dir}", remote_path="/app/src/leap_finetune", copy=True)
+            .env({{
+                "PYTHONPATH": "/app/src",
+                "LEAP_FINETUNE_DIR": "/app",
+                "RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE": "1",
+            }})
+        )
+
+        volume = modal.Volume.from_name("{output_volume}", create_if_missing=True)
+        secrets = [modal.Secret.from_name(s) for s in {secret_names!r}]
+
+        @app.function(
+            image=image,
+            gpu="{gpu}",
+            timeout={timeout},
+            volumes={{"{output_dir}": volume}},
+            secrets=secrets,
+            serialized=True,
+        )
+        def train(cfg: str) -> None:
+            import os, sys, tempfile
+            for prefix in ("leap_finetune", "huggingface_hub", "datasets", "fsspec"):
+                for mod_name in [m for m in sys.modules if m.startswith(prefix)]:
+                    del sys.modules[mod_name]
+            os.environ["LEAP_FINETUNE_DIR"] = "/app"
+            os.environ["OUTPUT_DIR"] = "{output_dir}"
+            os.environ.pop("HF_HUB_OFFLINE", None)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+                f.write(cfg)
+                tmp_path = f.name
+            sys.argv = ["leap-finetune", tmp_path]
+            from leap_finetune import main as leap_main
+            leap_main()
+
+        @app.local_entrypoint()
+        def main():
+            train.remote({config_str!r})
+    """)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, prefix="modal-train-"
+    ) as f:
+        f.write(script)
+        script_path = f.name
+
+    print(f"Submitting detached Modal job via 'modal run --detach'...")
+    result = subprocess.run(
+        ["modal", "run", "--detach", script_path],
+    )
+    os.unlink(script_path)
+
+    if result.returncode != 0:
+        print(f"modal run --detach failed with exit code {result.returncode}")
+        sys.exit(1)
+
+    print(f"\nMonitor with: modal app logs {app_name}")
 
 
 # === Image build ===


### PR DESCRIPTION
## Problem

`detach: true` in the Modal backend was non-functional because the function was spawned inside `app.run()` without detaching the app context. When the local context exited, the Modal app could be torn down even though `train.spawn()` had returned.

Detached runs also produced misleading monitor instructions: `modal app logs <app_name>` only resolves deployed Modal apps by name, while detached training uses an ephemeral app that must be referenced by its `ap-...` app ID.

## Changes

- Pass `detach=detach` into `app.run(...)` so detached spawned jobs keep the Modal app alive after local submission.
- Keep one Modal app/image/train definition path instead of generating a separate temporary Modal script.
- In detached mode, skip `modal.enable_output()` so submission behaves more like fire-and-forget and avoids waiting on Modal's log loop.
- Print the Modal app ID, dashboard URL, app-ID-based log command, and app-ID-based stop command after detached submission.
- Update README detached-mode docs to explain that ephemeral detached runs use the printed `ap-...` app ID for logs/stopping.

## Testing

- `uv run python -m py_compile src/leap_finetune/backends/modal_backend.py src/leap_finetune/__init__.py`
- `uv run ruff check src/leap_finetune/backends/modal_backend.py`
- Detached smoke submission confirmed the job continues in Modal after local submission; follow-up fix changed the printed monitor command from app name to app ID.