### PR TITLE
Add MoE expert parallel training runtime

### DIFF
--- a/job_configs/moe_ep_sft_example.yaml
+++ b/job_configs/moe_ep_sft_example.yaml
@@ -1,28 +1,25 @@
-project_name: "moe_ep_sft"
+project_name: "my_moe_ep_sft_project"
 model_name: "LFM2-24B-A2B"
 training_type: "moe_sft"
 
 dataset:
   path: "HuggingFaceTB/smoltalk"
   type: "sft"
-  limit: 500
+  limit: 1000
   test_size: 0.2
   subset: "all"
 
 training_config:
   extends: "MOE_SFT"
-  per_device_train_batch_size: 1
-  gradient_accumulation_steps: 4
-  learning_rate: 5e-5
   num_train_epochs: 1
-  max_steps: 20
+  per_device_train_batch_size: 1
+  learning_rate: 5e-5
 
   # Expert Parallelism: 8 GPUs = 2 DP × 4 EP
   # Each rank holds 16 of 64 experts; dp_size is inferred.
   moe_training:
     aux_loss_coef: 0.01
     z_loss_coef: 0.001
-    router_lr_ratio: 0.1
     expert_parallel_size: 4
 
 peft_config:

--- a/job_configs/moe_ep_sft_example.yaml
+++ b/job_configs/moe_ep_sft_example.yaml
@@ -1,25 +1,28 @@
-project_name: "my_moe_ep_sft_project"
+project_name: "moe_ep_sft"
 model_name: "LFM2-24B-A2B"
 training_type: "moe_sft"
 
 dataset:
   path: "HuggingFaceTB/smoltalk"
   type: "sft"
-  limit: 1000
+  limit: 500
   test_size: 0.2
   subset: "all"
 
 training_config:
   extends: "MOE_SFT"
-  num_train_epochs: 1
   per_device_train_batch_size: 1
+  gradient_accumulation_steps: 4
   learning_rate: 5e-5
+  num_train_epochs: 1
+  max_steps: 20
 
   # Expert Parallelism: 8 GPUs = 2 DP × 4 EP
   # Each rank holds 16 of 64 experts; dp_size is inferred.
   moe_training:
     aux_loss_coef: 0.01
     z_loss_coef: 0.001
+    router_lr_ratio: 0.1
     expert_parallel_size: 4
 
 peft_config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ requires-dist = ["torch", "einops", "ninja", "packaging", "setuptools", "wheel"]
 testpaths = ["tests"]
 markers = [
     "configs: config parsing, validation, override, filtering (no GPU)",
+    "data: data loading, validation, tokenization, and packing tests",
     "distribution: launch, resource planning, and backend integration tests (no GPU unless explicitly marked)",
     "evaluation: benchmark, metric, and async evaluation tests",
     "rl: RL data, rewards, rollout, and environment tests",

--- a/src/leap_finetune/training/moe_dpo.py
+++ b/src/leap_finetune/training/moe_dpo.py
@@ -222,7 +222,10 @@ def moe_dpo_run(training_config: dict) -> None:
         **train_config_filtered,
     }
     if use_ep or use_fsdp2:
-        validate_manual_sharded_training_args(config_kwargs)
+        validate_manual_sharded_training_args(
+            config_kwargs,
+            checkpoint_format=manual_sharded_checkpoint_format,
+        )
     if use_ep:
         logger.info(
             "EP mode: ep_size=%s, FSDP2 on dp_mesh, reshard_after_forward=%s",

--- a/src/leap_finetune/training/moe_sft.py
+++ b/src/leap_finetune/training/moe_sft.py
@@ -216,7 +216,10 @@ def moe_sft_run(training_config: dict) -> None:
     }
 
     if use_ep or use_fsdp2:
-        validate_manual_sharded_training_args(config_kwargs)
+        validate_manual_sharded_training_args(
+            config_kwargs,
+            checkpoint_format=manual_sharded_checkpoint_format,
+        )
         if use_ep:
             logger.info("EP mode: ep_size=%s, FSDP2 on dp_mesh", ep_size)
         else:

--- a/src/leap_finetune/training/utils/trainer_mixins.py
+++ b/src/leap_finetune/training/utils/trainer_mixins.py
@@ -47,7 +47,11 @@ class RayDataLoaderMixin:
         )
 
 
-def validate_manual_sharded_training_args(config_kwargs: dict) -> None:
+def validate_manual_sharded_training_args(
+    config_kwargs: dict,
+    *,
+    checkpoint_format: str | None = None,
+) -> None:
     """Reject Trainer args that conflict with the manual-sharded runtime."""
     if config_kwargs.get("gradient_checkpointing"):
         raise ValueError(
@@ -55,7 +59,9 @@ def validate_manual_sharded_training_args(config_kwargs: dict) -> None:
             "runs. This path already applies activation checkpointing in the FSDP2 "
             "wrapper; remove gradient_checkpointing from training_config."
         )
-    checkpoint_format = config_kwargs.get("manual_sharded_checkpoint_format")
+    checkpoint_format = checkpoint_format or config_kwargs.get(
+        "manual_sharded_checkpoint_format"
+    )
     if checkpoint_format is not None:
         try:
             normalize_manual_sharded_checkpoint_format(checkpoint_format)

--- a/tests/checkpoint_validation/validate_hf_checkpoint.py
+++ b/tests/checkpoint_validation/validate_hf_checkpoint.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def _find_checkpoint(run_root: Path, job_id: str) -> Path:
+    candidates = [
+        path
+        for path in run_root.rglob(f"*j{job_id}")
+        if path.is_dir() and (path / "config.json").is_file()
+    ]
+    if not candidates:
+        raise FileNotFoundError(
+            f"No HF checkpoint with config.json found under {run_root} for job {job_id}"
+        )
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def _safetensor_keys(checkpoint_dir: Path) -> list[str]:
+    paths = sorted(checkpoint_dir.glob("*.safetensors"))
+    if not paths:
+        raise FileNotFoundError(f"No safetensors files found in {checkpoint_dir}")
+
+    keys: list[str] = []
+    for path in paths:
+        with safe_open(path, framework="pt", device="cpu") as handle:
+            keys.extend(handle.keys())
+    return keys
+
+
+def _validate_expert_layout(checkpoint_dir: Path, expected_num_experts: int) -> None:
+    key_re = re.compile(
+        r"^(model\.layers\.\d+)\.feed_forward\.experts\.(\d+)\.w1\.weight$"
+    )
+    layer_experts: dict[str, set[int]] = {}
+
+    for key in _safetensor_keys(checkpoint_dir):
+        match = key_re.match(key)
+        if match is None:
+            continue
+        layer_experts.setdefault(match.group(1), set()).add(int(match.group(2)))
+
+    if not layer_experts:
+        raise AssertionError("No MoE expert tensors found in exported checkpoint")
+
+    expected_ids = set(range(expected_num_experts))
+    bad_layers = {
+        layer: sorted(ids)
+        for layer, ids in layer_experts.items()
+        if ids != expected_ids
+    }
+    if bad_layers:
+        preview = {
+            layer: {"count": len(ids), "first": ids[:4], "last": ids[-4:]}
+            for layer, ids in list(bad_layers.items())[:5]
+        }
+        raise AssertionError(
+            "Exported checkpoint does not contain the full expert set per MoE "
+            f"layer. Expected {expected_num_experts}; bad layer preview: {preview}"
+        )
+
+    print(
+        f"Expert layout OK: {len(layer_experts)} MoE layers x "
+        f"{expected_num_experts} experts"
+    )
+
+
+def _generate_text(checkpoint_dir: Path, prompt: str, max_new_tokens: int) -> None:
+    tokenizer = AutoTokenizer.from_pretrained(
+        checkpoint_dir,
+        trust_remote_code=True,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        checkpoint_dir,
+        torch_dtype=torch.bfloat16,
+        device_map={"": "cuda:0"},
+        trust_remote_code=True,
+        low_cpu_mem_usage=True,
+    )
+    model.eval()
+
+    inputs = tokenizer(prompt, return_tensors="pt").to("cuda")
+    with torch.inference_mode():
+        output_ids = model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            do_sample=False,
+            pad_token_id=tokenizer.eos_token_id,
+        )
+
+    if output_ids.shape[-1] <= inputs["input_ids"].shape[-1]:
+        raise AssertionError("Generation produced no new tokens")
+
+    text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+    print("Generated text:")
+    print(text)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate an exported HF checkpoint has all MoE experts and loads."
+    )
+    parser.add_argument(
+        "--run-root", type=Path, default=Path("/lambdafs/alay/checkpoints")
+    )
+    parser.add_argument("--job-id", required=True)
+    parser.add_argument("--expected-num-experts", type=int, default=None)
+    parser.add_argument(
+        "--prompt", default="Explain expert parallelism in one sentence."
+    )
+    parser.add_argument("--max-new-tokens", type=int, default=16)
+    args = parser.parse_args()
+
+    checkpoint_dir = _find_checkpoint(args.run_root, args.job_id)
+    print(f"Validating checkpoint: {checkpoint_dir}")
+
+    with open(checkpoint_dir / "config.json") as handle:
+        config = json.load(handle)
+    expected_num_experts = args.expected_num_experts or int(config["num_experts"])
+
+    _validate_expert_layout(checkpoint_dir, expected_num_experts)
+    _generate_text(checkpoint_dir, args.prompt, args.max_new_tokens)
+    print("HF checkpoint validation passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slurm/submit_e2e_tests.sh
+++ b/tests/slurm/submit_e2e_tests.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Submit the GPU e2e pytest suite as one SLURM allocation. This keeps the
+# tests' normal in-process assertions while letting Ray/torch see SLURM GPUs.
+
+usage() {
+    cat <<'EOF'
+Usage: tests/slurm/submit_e2e_tests.sh [--dry-run]
+
+Environment overrides:
+  JOB_NAME                 SLURM job name (default: leap_e2e_tests)
+  PARTITION                Optional SLURM partition
+  NODES                    Number of nodes (default: 1)
+  GPUS_PER_TASK            GPUs in the allocation (default: 4)
+  CPUS_PER_GPU             CPUs per GPU (default: 14)
+  TIME_LIMIT               SLURM time limit (default: 06:00:00)
+  OUTPUT_DIR               Test result directory (default: /lambdafs/alay/test-results)
+  TMP_ROOT                 Node temp root (default: /lambdafs/alay/tmp)
+  PYTEST_ARGS              pytest args to run inside SLURM
+  EXTRA_SBATCH_DIRECTIVES  Newline-separated extra #SBATCH directives
+EOF
+}
+
+DRY_RUN=0
+for arg in "$@"; do
+    case "${arg}" in
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: ${arg}" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SLURM_DIR="${ROOT_DIR}/tests/slurm/generated"
+SCRIPT_PATH="${SLURM_DIR}/e2e_tests.sh"
+
+JOB_NAME="${JOB_NAME:-leap_e2e_tests}"
+PARTITION="${PARTITION:-}"
+NODES="${NODES:-1}"
+GPUS_PER_TASK="${GPUS_PER_TASK:-4}"
+CPUS_PER_GPU="${CPUS_PER_GPU:-14}"
+TIME_LIMIT="${TIME_LIMIT:-06:00:00}"
+OUTPUT_DIR="${OUTPUT_DIR:-/lambdafs/alay/test-results}"
+TMP_ROOT="${TMP_ROOT:-/lambdafs/alay/tmp}"
+PYTEST_ARGS="${PYTEST_ARGS:-tests/test_dense_e2e.py tests/test_moe_e2e.py tests/test_vlm_e2e.py --dense --moe --vlm}"
+EXTRA_SBATCH_DIRECTIVES="${EXTRA_SBATCH_DIRECTIVES:-}"
+
+mkdir -p "${SLURM_DIR}" "${ROOT_DIR}/logs" "${OUTPUT_DIR}" "${TMP_ROOT}"
+
+{
+    cat <<EOF
+#!/usr/bin/env bash
+#SBATCH --job-name=${JOB_NAME}
+#SBATCH --nodes=${NODES}
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-task=${GPUS_PER_TASK}
+#SBATCH --cpus-per-gpu=${CPUS_PER_GPU}
+#SBATCH --time=${TIME_LIMIT}
+#SBATCH --output=logs/OUT_%x.%j
+#SBATCH --error=logs/ERR_%x.%j
+EOF
+
+    if [[ -n "${PARTITION}" ]]; then
+        echo "#SBATCH --partition=${PARTITION}"
+    fi
+
+    if [[ -n "${EXTRA_SBATCH_DIRECTIVES}" ]]; then
+        while IFS= read -r directive; do
+            [[ -n "${directive}" ]] && echo "#SBATCH ${directive}"
+        done <<< "${EXTRA_SBATCH_DIRECTIVES}"
+    fi
+
+    cat <<EOF
+
+set -euo pipefail
+
+cd ${ROOT_DIR}
+source .venv/bin/activate
+
+export TMPDIR=${TMP_ROOT}/leap-e2e-\${SLURM_JOB_ID:-manual}
+mkdir -p "\${TMPDIR}"
+export RAY_TMPDIR=\${TMPDIR}/ray
+export OUTPUT_DIR=${OUTPUT_DIR}
+export PYTHONUNBUFFERED=1
+
+uv run pytest ${PYTEST_ARGS}
+
+echo "================================================"
+echo "E2E TESTS DONE"
+echo "================================================"
+EOF
+} > "${SCRIPT_PATH}"
+
+chmod +x "${SCRIPT_PATH}"
+if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "Generated SLURM script: ${SCRIPT_PATH}"
+else
+    sbatch "${SCRIPT_PATH}"
+fi

--- a/tests/test_checkpoint_callback.py
+++ b/tests/test_checkpoint_callback.py
@@ -1,0 +1,84 @@
+import pytest
+from transformers import TrainingArguments
+
+from leap_finetune.checkpointing.paths import (
+    rename_standard_checkpoint,
+    rotate_named_checkpoints,
+)
+from leap_finetune.checkpointing.callback import LeapCheckpointCallback
+
+pytestmark = pytest.mark.configs
+
+
+class TestCheckpointCallback:
+    def test_create_without_template(self):
+        cb = LeapCheckpointCallback()
+        assert cb.run_name_template is None
+        assert cb.metrics == {}
+
+    def test_create_with_template(self):
+        cb = LeapCheckpointCallback(run_name_template="test-run-20250101")
+        assert cb.run_name_template == "test-run-20250101"
+
+    def test_on_log_accumulates_metrics(self, tmp_path):
+        cb = LeapCheckpointCallback()
+        args = TrainingArguments(output_dir=str(tmp_path), report_to="none")
+        state = type("State", (), {"epoch": 1, "global_step": 10})()
+        control = type("Control", (), {})()
+
+        cb.on_log(args, state, control, logs={"loss": 1.5, "lr": 1e-4})
+        assert cb.metrics == {"loss": 1.5, "lr": 1e-4}
+
+        # Later log overwrites earlier values
+        cb.on_log(args, state, control, logs={"loss": 0.8})
+        assert cb.metrics["loss"] == 0.8
+        assert cb.metrics["lr"] == 1e-4  # preserved
+
+    def test_on_log_ignores_none(self, tmp_path):
+        cb = LeapCheckpointCallback()
+        args = TrainingArguments(output_dir=str(tmp_path), report_to="none")
+        state = type("State", (), {})()
+        control = type("Control", (), {})()
+
+        cb.on_log(args, state, control, logs=None)
+        assert cb.metrics == {}
+
+    def test_rename_checkpoint(self, tmp_path):
+        # Create a fake checkpoint dir
+        checkpoint_dir = tmp_path / "checkpoint-100"
+        checkpoint_dir.mkdir()
+        (checkpoint_dir / "model.safetensors").touch()
+
+        rename_standard_checkpoint(
+            output_dir=str(tmp_path),
+            run_name_template="LFM2-sft-smoltalk-20250101_120000",
+            epoch=1.0,
+            step=100,
+            save_total_limit=None,
+        )
+
+        # Original should be gone
+        assert not checkpoint_dir.exists()
+        # Renamed dir should exist with epoch/step pattern
+        renamed = list(tmp_path.glob("LFM2-sft-smoltalk-e1s100-*"))
+        assert len(renamed) == 1
+        assert (renamed[0] / "model.safetensors").exists()
+        # Latest symlink should point to it
+        latest = tmp_path / "latest"
+        assert latest.is_symlink()
+        assert latest.resolve() == renamed[0].resolve()
+
+    def test_rotate_checkpoints(self, tmp_path):
+        # Create 4 checkpoint dirs
+        for step in [10, 20, 30, 40]:
+            d = tmp_path / f"model-e1s{step}-20250101"
+            d.mkdir()
+            (d / "model.safetensors").touch()
+
+        rotate_named_checkpoints(tmp_path, limit=2)
+
+        remaining = sorted(d.name for d in tmp_path.iterdir() if d.is_dir())
+        # Should keep the 2 newest (highest step): s30 and s40
+        assert len(remaining) == 2
+        assert "model-e1s30-20250101" in remaining
+        assert "model-e1s40-20250101" in remaining

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -714,7 +714,7 @@ class TestSlurmGeneration:
             assert "leap-finetune" in content
 
     def test_generate_multinode_slurm_script_starts_ray_cluster(self, tmp_path):
-        from leap_finetune.utils.slurm_generator import generate_slurm_script
+        from leap_finetune.distribution.backends.slurm import generate_slurm_script
 
         config = {
             "project_name": "multi_node_grpo",
@@ -732,13 +732,13 @@ class TestSlurmGeneration:
         script_path = generate_slurm_script(config_path, config, tmp_path)
         content = script_path.read_text()
 
-        assert "source job_configs/slurms/utils/slurm_ray.sh" in content
-        assert "ray_slurm_init 2 1" in content
-        assert "ray_slurm_wait_ready 2 2" in content
+        assert "slurm_ray.sh" in content
+        assert 'ray_slurm_init "${SLURM_NNODES}" "1"' in content
+        assert 'ray_slurm_wait_ready "${SLURM_NNODES}" "${TOTAL_GPUS}"' in content
         assert "trap ray_slurm_stop_cluster EXIT" in content
 
     def test_generate_server_mode_slurm_defaults_to_two_gpus(self, tmp_path):
-        from leap_finetune.utils.slurm_generator import generate_slurm_script
+        from leap_finetune.distribution.backends.slurm import generate_slurm_script
 
         config = {
             "project_name": "server_grpo",
@@ -758,7 +758,7 @@ class TestSlurmGeneration:
         assert "#SBATCH --gpus-per-task=2" in content
 
     def test_generate_grpo_judge_slurm_defaults_to_extra_gpu(self, tmp_path):
-        from leap_finetune.utils.slurm_generator import generate_slurm_script
+        from leap_finetune.distribution.backends.slurm import generate_slurm_script
 
         config = {
             "project_name": "judge_grpo",
@@ -775,7 +775,7 @@ class TestSlurmGeneration:
         assert "#SBATCH --gpus-per-task=2" in content
 
     def test_generate_server_mode_judge_slurm_defaults_to_three_gpus(self, tmp_path):
-        from leap_finetune.utils.slurm_generator import generate_slurm_script
+        from leap_finetune.distribution.backends.slurm import generate_slurm_script
 
         config = {
             "project_name": "judge_server_grpo",

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -1,0 +1,796 @@
+import pathlib
+
+import pytest
+import yaml
+from peft import LoraConfig
+
+from leap_finetune.config.parser import (
+    generate_run_name,
+    parse_job_config,
+    resolve_config_path,
+)
+from leap_finetune import LEAP_FINETUNE_DIR
+
+from conftest import BASE_DPO_DATASET, BASE_SFT_DATASET, BASE_VLM_DATASET, write_config
+
+pytestmark = pytest.mark.configs
+
+
+# === Config path resolution ===
+
+
+class TestResolveConfigPath:
+    def test_absolute_path(self, sft_config_path):
+        result = resolve_config_path(sft_config_path)
+        assert result.exists()
+        assert result.name == "sft_example.yaml"
+
+    def test_repo_job_configs(self):
+        result = resolve_config_path("sft_example.yaml")
+        assert result.exists()
+
+    def test_not_found_raises(self):
+        with pytest.raises(FileNotFoundError):
+            resolve_config_path("nonexistent_config.yaml")
+
+
+# === Run name generation ===
+
+
+class TestGenerateRunName:
+    def test_basic_format(self):
+        name = generate_run_name(
+            model_name="LFM2-1.2B",
+            training_type="sft",
+            dataset_path="HuggingFaceTB/smoltalk",
+            dataset_limit=1000,
+            learning_rate=2e-5,
+            warmup_ratio=0.2,
+            use_peft=True,
+            lora_type="a",
+        )
+        assert "LFM2-1.2B" in name
+        assert "sft" in name
+        assert "smoltalk" in name
+        assert "1000" in name
+        assert "lora_a" in name
+
+    def test_no_peft(self):
+        name = generate_run_name(
+            model_name="LFM2-1.2B",
+            training_type="dpo",
+            dataset_path="some/dataset",
+            dataset_limit=None,
+            learning_rate=None,
+            warmup_ratio=None,
+            use_peft=False,
+        )
+        assert "no_lora" in name
+        assert "all" in name
+        assert "lr_def" in name
+        assert "w_def" in name
+
+    def test_long_dataset_name_truncated(self):
+        name = generate_run_name(
+            model_name="m",
+            training_type="sft",
+            dataset_path="very_long_dataset_name_here",
+            dataset_limit=None,
+            learning_rate=None,
+            warmup_ratio=None,
+            use_peft=False,
+        )
+        parts = name.split("-")
+        assert len(parts[2]) <= 10
+
+
+# === YAML parsing ===
+
+
+class TestParseJobConfig:
+    def test_parse_sft_example(self, sft_config_path):
+        job = parse_job_config(sft_config_path)
+        assert job.training_type == "sft"
+        assert job.model_name == "LFM2-1.2B"
+        assert job.job_name == "my_sft_project"
+        assert job.dataset.dataset_path == "HuggingFaceTB/smoltalk"
+        assert job.dataset.dataset_type == "sft"
+        assert "deepspeed" in job.training_config.value
+        assert "learning_rate" in job.training_config.value
+
+    def test_parse_dpo_example(self, dpo_config_path):
+        job = parse_job_config(dpo_config_path)
+        assert job.training_type == "dpo"
+        assert job.job_name == "my_dpo_project"
+        assert job.dataset.dataset_type == "dpo"
+        assert "beta" in job.training_config.value
+        assert "deepspeed" in job.training_config.value
+
+    def test_parse_vlm_example(self, vlm_config_path):
+        job = parse_job_config(vlm_config_path)
+        assert job.training_type == "vlm_sft"
+        assert job.job_name == "my_vlm_project"
+        assert job.dataset.dataset_type == "vlm_sft"
+        assert "deepspeed" in job.training_config.value
+
+    def test_parse_moe_sft_example(self, moe_sft_config_path):
+        job = parse_job_config(moe_sft_config_path)
+        assert job.training_type == "moe_sft"
+        assert job.model_name == "LFM2-8B-A1B"
+        assert job.dataset.dataset_type == "sft"
+        ds_config = job.training_config.value.get("deepspeed", {})
+        assert ds_config.get("zero_optimization", {}).get("stage") == 0
+
+    def test_parse_moe_dpo_example(self, moe_dpo_config_path):
+        job = parse_job_config(moe_dpo_config_path)
+        assert job.training_type == "moe_dpo"
+        assert job.model_name == "LFM2-8B-A1B"
+        assert job.dataset.dataset_type == "dpo"
+
+
+# === Config extends/inheritance ===
+
+
+class TestExtendsResolution:
+    def test_extends_default_sft(self, sft_config_path):
+        job = parse_job_config(sft_config_path)
+        config = job.training_config.value
+        assert config["num_train_epochs"] == 3
+        assert config["per_device_train_batch_size"] == 2
+        assert config["learning_rate"] == 2e-5
+        assert config["training_type"] == "sft"
+        assert "deepspeed" in config
+
+    def test_extends_moe_sft(self, moe_sft_config_path):
+        job = parse_job_config(moe_sft_config_path)
+        config = job.training_config.value
+        assert config["num_train_epochs"] == 2
+        assert config["per_device_train_batch_size"] == 2
+
+    def test_peft_extends_default_lora(self, sft_config_path):
+        job = parse_job_config(sft_config_path)
+        peft_value = job.peft_config.value
+        assert peft_value is not None
+        assert hasattr(peft_value, "r")
+        assert peft_value.r == 8
+
+    def test_peft_extends_moe_lora(self, moe_sft_config_path):
+        job = parse_job_config(moe_sft_config_path)
+        peft_value = job.peft_config.value
+        assert peft_value is not None
+        assert peft_value.target_modules == "all-linear"
+
+
+# === PEFT overrides ===
+
+
+class TestPeftOverrides:
+    def test_override_r_value(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"extends": "DEFAULT_LORA", "use_peft": True, "r": 32},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        peft_val = job.peft_config.value
+        assert isinstance(peft_val, LoraConfig)
+        assert peft_val.r == 32
+
+    def test_override_alpha_preserves_r(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {
+                "extends": "DEFAULT_LORA",
+                "use_peft": True,
+                "lora_alpha": 64,
+            },
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        peft_val = job.peft_config.value
+        assert peft_val.lora_alpha == 64
+        assert peft_val.r == 8
+
+    def test_use_peft_false_disables(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.peft_config is None
+
+    def test_use_peft_true_without_extends_uses_default(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": True},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        from leap_finetune.training.default_configs import PeftConfig
+
+        assert job.peft_config is PeftConfig.DEFAULT_LORA
+
+    def test_no_peft_section_gives_none(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.peft_config is None
+
+    def test_extends_vlm_lora_with_dropout_override(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "vlm_sft",
+            "dataset": BASE_VLM_DATASET,
+            "training_config": {"extends": "DEFAULT_VLM_SFT"},
+            "peft_config": {
+                "extends": "DEFAULT_VLM_LORA",
+                "use_peft": True,
+                "lora_dropout": 0.3,
+            },
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        peft_val = job.peft_config.value
+        assert peft_val.lora_dropout == 0.3
+        assert peft_val.r == 8
+
+    def test_extends_high_r_lora(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"extends": "HIGH_R_LORA", "use_peft": True},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        peft_val = job.peft_config.value
+        assert peft_val.r == 16
+        assert peft_val.lora_alpha == 32
+
+    def test_peft_value_accessible_via_dot_value(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"extends": "DEFAULT_LORA", "use_peft": True, "r": 4},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert hasattr(job.peft_config, "value")
+        assert job.peft_config.value.r == 4
+
+
+# === Training config overrides ===
+
+
+class TestTrainingConfigOverrides:
+    def test_learning_rate_string_coercion(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT", "learning_rate": "1e-4"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        lr = job.training_config.value["learning_rate"]
+        assert isinstance(lr, float)
+        assert lr == 1e-4
+
+    def test_backward_compat_no_extends(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "dpo",
+            "dataset": BASE_DPO_DATASET,
+            "training_config": {"num_train_epochs": 5, "learning_rate": 2e-6},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        config_val = job.training_config.value
+        assert config_val["training_type"] == "dpo"
+        assert config_val["beta"] == 0.1
+        assert config_val["num_train_epochs"] == 5
+        assert config_val["learning_rate"] == 2e-6
+
+    def test_base_keyword_works_like_extends(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"base": "DEFAULT_SFT", "num_train_epochs": 10},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.training_config.value["num_train_epochs"] == 10
+        assert "deepspeed" in job.training_config.value
+
+
+# === All example configs ===
+
+
+class TestAllExampleConfigs:
+    @pytest.fixture
+    def job_configs_dir(self):
+        return LEAP_FINETUNE_DIR / "job_configs"
+
+    EXPECTED = {
+        "sft_example.yaml": {"type": "sft", "model": "LFM2-1.2B", "has_peft": True},
+        "dpo_example.yaml": {"type": "dpo", "model": "LFM2-1.2B", "has_peft": True},
+        "vlm_sft_example.yaml": {
+            "type": "vlm_sft",
+            "model": "LFM2-1.2B",
+            "has_peft": True,
+        },
+        "moe_sft_example.yaml": {
+            "type": "moe_sft",
+            "model": "LFM2-8B-A1B",
+            "has_peft": True,
+        },
+        "moe_dpo_example.yaml": {
+            "type": "moe_dpo",
+            "model": "LFM2-8B-A1B",
+            "has_peft": True,
+        },
+        "sft_example_with_slurm.yaml": {
+            "type": "sft",
+            "model": "LFM2-1.2B",
+            "has_peft": True,
+        },
+        "sft_with_lora_example.yaml": {
+            "type": "sft",
+            "model": "LFM2-1.2B",
+            "has_peft": True,
+        },
+    }
+
+    @pytest.mark.parametrize("config_name", list(EXPECTED.keys()))
+    def test_parse_and_to_dict(self, job_configs_dir, config_name):
+        config_path = str(job_configs_dir / config_name)
+        job = parse_job_config(config_path)
+        expected = self.EXPECTED[config_name]
+
+        d = job.to_dict()
+        assert isinstance(d["training_config"], dict)
+        assert d["training_type"] == expected["type"]
+        assert d["model_name"] == expected["model"]
+
+        from leap_finetune.data_loading.dataset_loader import DatasetLoader
+
+        assert isinstance(d["dataset"], DatasetLoader)
+        assert d["dataset"].dataset_path, "dataset_path is empty"
+
+        tc = d["training_config"]
+        assert "output_dir" in tc
+        assert "learning_rate" in tc
+        assert isinstance(tc["learning_rate"], float)
+
+        if expected["has_peft"]:
+            assert d["peft_config"] is not None, (
+                f"{config_name} should have peft_config"
+            )
+
+
+# === Output dir and env overrides ===
+
+
+class TestOutputAndEnv:
+    def test_output_dir_created(self, tmp_path):
+        config = {
+            "project_name": "test_output_creation",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        output_dir = pathlib.Path(job.training_config.value["output_dir"])
+        assert output_dir.exists()
+
+    def test_output_dir_env_override(self, tmp_path, monkeypatch):
+        env_dir = str(tmp_path / "env_output")
+        pathlib.Path(env_dir).mkdir()
+        monkeypatch.setenv("OUTPUT_DIR", env_dir)
+        config = {
+            "project_name": "test_env_override",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        output_dir = job.training_config.value["output_dir"]
+        assert output_dir.startswith(env_dir), (
+            f"output_dir should be under OUTPUT_DIR: {output_dir}"
+        )
+
+    def test_dataset_path_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DATASET_PATH", "custom/override/dataset")
+        config = {
+            "project_name": "test_ds_override",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.dataset.dataset_path == "custom/override/dataset"
+
+    def test_dataset_path_falls_back_to_yaml(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DATASET_PATH", raising=False)
+        config = {
+            "project_name": "test_ds_fallback",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.dataset.dataset_path == BASE_SFT_DATASET["path"]
+
+
+# === Run name in config ===
+
+
+class TestRunNameInConfig:
+    def test_run_name_has_model_info(self, tmp_path):
+        config = {
+            "project_name": "test_rn",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT", "learning_rate": 2e-5},
+            "peft_config": {"extends": "DEFAULT_LORA", "use_peft": True},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        run_name = job.training_config.value["leap_run_name_template"]
+        assert "LFM2" in run_name
+        assert "sft" in run_name
+        assert "lora_a" in run_name
+
+    def test_run_name_no_peft(self, tmp_path):
+        config = {
+            "project_name": "test_rn",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        run_name = job.training_config.value["leap_run_name_template"]
+        assert "no_lora" in run_name
+
+
+# === Invalid configs ===
+
+
+class TestModelName:
+    def test_model_name_passed_to_loader(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2.5-1.2B-Instruct",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.dataset.model_name == "LFM2.5-1.2B-Instruct"
+
+    def test_default_model_name(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.dataset.model_name == "LFM2-1.2B"
+
+
+class TestInvalidConfigs:
+    def test_unknown_extends_raises(self, tmp_path):
+        config = {
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "NONEXISTENT_CONFIG"},
+        }
+        with pytest.raises(ValueError, match="Unknown base config"):
+            parse_job_config(write_config(config, tmp_path))
+
+    def test_unknown_peft_extends_raises(self, tmp_path):
+        config = {
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"extends": "NONEXISTENT_LORA", "use_peft": True},
+        }
+        with pytest.raises(ValueError, match="Unknown base PEFT config"):
+            parse_job_config(write_config(config, tmp_path))
+
+    def test_unknown_training_type_raises(self, tmp_path):
+        config = {
+            "model_name": "LFM2-1.2B",
+            "training_type": "invalid_type",
+            "dataset": BASE_SFT_DATASET,
+        }
+        with pytest.raises(ValueError, match="Unknown training type"):
+            parse_job_config(write_config(config, tmp_path))
+
+
+# === to_dict ===
+
+
+class TestJobConfigToDict:
+    def test_to_dict_has_required_keys(self, sft_config_path):
+        job = parse_job_config(sft_config_path)
+        d = job.to_dict()
+        assert "model_name" in d
+        assert "job_name" in d
+        assert "training_type" in d
+        assert "training_config" in d
+        assert "dataset" in d
+        assert "peft_config" in d
+
+    def test_to_dict_training_config_is_dict(self, sft_config_path):
+        job = parse_job_config(sft_config_path)
+        d = job.to_dict()
+        assert isinstance(d["training_config"], dict)
+
+    def test_run_name_template_in_training_config(self, sft_config_path):
+        job = parse_job_config(sft_config_path)
+        d = job.to_dict()
+        assert "leap_run_name_template" in d["training_config"]
+
+    def test_to_dict_peft_is_lora_config(self, sft_config_path):
+        job = parse_job_config(sft_config_path)
+        d = job.to_dict()
+        assert isinstance(d["peft_config"], LoraConfig)
+
+    def test_to_dict_no_peft(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        assert d["peft_config"] is None
+
+
+# === Project name fallback ===
+
+
+class TestProjectNameFallback:
+    def test_project_name_used(self, sft_config_path):
+        job = parse_job_config(sft_config_path)
+        assert job.job_name == "my_sft_project"
+
+    def test_job_name_fallback(self, tmp_path):
+        config = {
+            "job_name": "test_job",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.job_name == "test_job"
+
+    def test_default_fallback(self, tmp_path):
+        config = {
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.job_name == "default_job"
+
+
+# === Benchmark config passthrough ===
+
+
+class TestBenchmarkConfig:
+    def test_benchmarks_parsed_from_yaml(self, tmp_path):
+        config = {
+            "project_name": "test_bench",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+            "benchmarks": {
+                "max_new_tokens": 64,
+                "benchmarks": [
+                    {
+                        "name": "eval1",
+                        "path": "/data/eval.jsonl",
+                        "metric": "short_answer",
+                    },
+                ],
+            },
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.benchmark_configs is not None
+        assert len(job.benchmark_configs["benchmarks"]) == 1
+        assert job.benchmark_configs["max_new_tokens"] == 64
+
+    def test_no_benchmarks_gives_none(self, tmp_path):
+        config = {
+            "project_name": "test_no_bench",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        assert job.benchmark_configs is None
+
+    def test_benchmarks_in_to_dict(self, tmp_path):
+        config = {
+            "project_name": "test_bench_dict",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+            "benchmarks": {
+                "benchmarks": [
+                    {"name": "e", "path": "/data/e.jsonl", "metric": "mcq_gen"},
+                ],
+            },
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        assert "benchmark_configs" in d
+        assert d["benchmark_configs"]["benchmarks"][0]["name"] == "e"
+
+
+# === SLURM generation ===
+
+
+class TestSlurmGeneration:
+    def test_slurm_config_parsed(self, slurm_config_path):
+        with open(slurm_config_path) as f:
+            config = yaml.safe_load(f)
+        assert "slurm" in config
+        assert config["slurm"]["job_name"] == "sft_training"
+        assert config["slurm"]["gpus_per_task"] == 4
+
+    def test_generate_slurm_script(self, slurm_config_path):
+        import tempfile
+
+        from leap_finetune.distribution.backends.slurm import generate_slurm_script
+
+        config_path = pathlib.Path(slurm_config_path)
+        with open(config_path) as f:
+            config_dict = yaml.safe_load(f)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = pathlib.Path(tmpdir)
+            script_path = generate_slurm_script(
+                config_path, config_dict, output_dir, auto_submit=False
+            )
+            assert script_path.exists()
+            content = script_path.read_text()
+            assert "#!/bin/bash" in content
+            assert "#SBATCH --job-name=sft_training" in content
+            assert "#SBATCH --gpus-per-task=4" in content
+            assert "LEAP_FINETUNE_FROM_SLURM=1" in content
+            assert "leap-finetune" in content
+
+    def test_generate_multinode_slurm_script_starts_ray_cluster(self, tmp_path):
+        from leap_finetune.utils.slurm_generator import generate_slurm_script
+
+        config = {
+            "project_name": "multi_node_grpo",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_GRPO"},
+            "slurm": {
+                "nodes": 2,
+                "ntasks_per_node": 1,
+                "gpus_per_task": 1,
+            },
+        }
+        config_path = pathlib.Path(write_config(config, tmp_path))
+        script_path = generate_slurm_script(config_path, config, tmp_path)
+        content = script_path.read_text()
+
+        assert "source job_configs/slurms/utils/slurm_ray.sh" in content
+        assert "ray_slurm_init 2 1" in content
+        assert "ray_slurm_wait_ready 2 2" in content
+        assert "trap ray_slurm_stop_cluster EXIT" in content
+
+    def test_generate_server_mode_slurm_defaults_to_two_gpus(self, tmp_path):
+        from leap_finetune.utils.slurm_generator import generate_slurm_script
+
+        config = {
+            "project_name": "server_grpo",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": BASE_SFT_DATASET,
+            "grpo_rollout": {"server_gpus": 1},
+            "training_config": {
+                "extends": "DEFAULT_GRPO",
+                "vllm_mode": "server",
+            },
+        }
+        config_path = pathlib.Path(write_config(config, tmp_path))
+        script_path = generate_slurm_script(config_path, config, tmp_path)
+        content = script_path.read_text()
+
+        assert "#SBATCH --gpus-per-task=2" in content
+
+    def test_generate_grpo_judge_slurm_defaults_to_extra_gpu(self, tmp_path):
+        from leap_finetune.utils.slurm_generator import generate_slurm_script
+
+        config = {
+            "project_name": "judge_grpo",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": BASE_SFT_DATASET,
+            "rewards": {"judge": {"model": "LFM2-1.2B"}},
+            "training_config": {"extends": "DEFAULT_GRPO"},
+        }
+        config_path = pathlib.Path(write_config(config, tmp_path))
+        script_path = generate_slurm_script(config_path, config, tmp_path)
+        content = script_path.read_text()
+
+        assert "#SBATCH --gpus-per-task=2" in content
+
+    def test_generate_server_mode_judge_slurm_defaults_to_three_gpus(self, tmp_path):
+        from leap_finetune.utils.slurm_generator import generate_slurm_script
+
+        config = {
+            "project_name": "judge_server_grpo",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": BASE_SFT_DATASET,
+            "grpo_rollout": {"server_gpus": 1},
+            "rewards": {"judge": {"model": "LFM2-1.2B"}},
+            "training_config": {
+                "extends": "DEFAULT_GRPO",
+                "vllm_mode": "server",
+            },
+        }
+        config_path = pathlib.Path(write_config(config, tmp_path))
+        script_path = generate_slurm_script(config_path, config, tmp_path)
+        content = script_path.read_text()
+
+        assert "#SBATCH --gpus-per-task=3" in content

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -348,6 +348,11 @@ class TestAllExampleConfigs:
             "model": "LFM2-8B-A1B",
             "has_peft": True,
         },
+        "moe_ep_sft_example.yaml": {
+            "type": "moe_sft",
+            "model": "LFM2-24B-A2B",
+            "has_peft": False,
+        },
         "moe_dpo_example.yaml": {
             "type": "moe_dpo",
             "model": "LFM2-8B-A1B",

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -6,7 +6,8 @@ from peft import LoraConfig
 
 from leap_finetune.config.parser import (
     generate_run_name,
-    parse_job_config,
+    materialize_job_config,
+    parse_job_config as _parse_job_config,
     resolve_config_path,
 )
 from leap_finetune import LEAP_FINETUNE_DIR
@@ -14,6 +15,10 @@ from leap_finetune import LEAP_FINETUNE_DIR
 from conftest import BASE_DPO_DATASET, BASE_SFT_DATASET, BASE_VLM_DATASET, write_config
 
 pytestmark = pytest.mark.configs
+
+
+def parse_job_config(config_input):
+    return materialize_job_config(_parse_job_config(config_input))
 
 
 # === Config path resolution ===
@@ -219,9 +224,10 @@ class TestPeftOverrides:
             "peft_config": {"use_peft": True},
         }
         job = parse_job_config(write_config(config, tmp_path))
-        from leap_finetune.training.default_configs import PeftConfig
+        from leap_finetune.training.default_configs import PEFT_DEFAULTS
 
-        assert job.peft_config is PeftConfig.DEFAULT_LORA
+        assert job.peft_config is not None
+        assert job.peft_config.value is PEFT_DEFAULTS["DEFAULT_LORA"]
 
     def test_no_peft_section_gives_none(self, tmp_path):
         config = {
@@ -546,7 +552,7 @@ class TestInvalidConfigs:
             "training_type": "invalid_type",
             "dataset": BASE_SFT_DATASET,
         }
-        with pytest.raises(ValueError, match="Unknown training type"):
+        with pytest.raises(ValueError, match="Invalid config"):
             parse_job_config(write_config(config, tmp_path))
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -96,7 +96,7 @@ class TestToolCallValidation:
                 }
             ]
         )
-        with pytest.raises(ValueError, match="tool_calls.*not supported"):
+        with pytest.raises(ValueError, match="no tool response"):
             validate_sft_format(ds)
 
     def test_sft_missing_tool_response_rejected(self):
@@ -195,7 +195,7 @@ class TestToolCallValidation:
                     ]
                 }
             )
-            is False
+            is True
         )
 
     def test_dpo_row_filter_rejects_foreign_markers(self):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,535 @@
+import pytest
+
+from datasets import Dataset
+
+pytestmark = pytest.mark.data
+
+
+# === Tool call validation ===
+
+
+class TestToolCallValidation:
+    # --- SFT ---
+
+    def test_sft_foreign_markers_rejected(self):
+        from leap_finetune.data_loading.validate_dataset_format import (
+            validate_sft_format,
+        )
+
+        for marker, fmt in [("<tool_call>", "Qwen"), ("[TOOL_CALLS]", "Mistral")]:
+            ds = Dataset.from_list(
+                [
+                    {
+                        "messages": [
+                            {"role": "user", "content": "Hi"},
+                            {
+                                "role": "assistant",
+                                "content": f"{marker} foo {marker.replace('<', '</')}",
+                            },
+                        ]
+                    }
+                ]
+            )
+            with pytest.raises(ValueError, match=f"{fmt} tool call markers"):
+                validate_sft_format(ds)
+
+    def test_sft_correct_lfm_format_passes(self):
+        from leap_finetune.data_loading.validate_dataset_format import (
+            validate_sft_format,
+        )
+
+        ds = Dataset.from_list(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "Get weather"},
+                        {
+                            "role": "assistant",
+                            "content": '<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>\nChecking now.',
+                        },
+                        {"role": "tool", "content": '{"temp": 18}'},
+                        {"role": "assistant", "content": "It's 18 degrees."},
+                    ]
+                }
+            ]
+        )
+        assert len(validate_sft_format(ds)) == 1
+
+    def test_sft_text_before_tool_call_rejected(self):
+        from leap_finetune.data_loading.validate_dataset_format import (
+            validate_sft_format,
+        )
+
+        ds = Dataset.from_list(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "Get weather"},
+                        {
+                            "role": "assistant",
+                            "content": 'Sure thing!\n<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>',
+                        },
+                        {"role": "tool", "content": '{"temp": 18}'},
+                    ]
+                }
+            ]
+        )
+        with pytest.raises(ValueError, match="Text appears before tool call"):
+            validate_sft_format(ds)
+
+    def test_sft_structured_tool_calls_field_rejected(self):
+        from leap_finetune.data_loading.validate_dataset_format import (
+            validate_sft_format,
+        )
+
+        ds = Dataset.from_list(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "Hi"},
+                        {
+                            "role": "assistant",
+                            "content": "Let me check.",
+                            "tool_calls": [{"name": "get_weather"}],
+                        },
+                    ]
+                }
+            ]
+        )
+        with pytest.raises(ValueError, match="tool_calls.*not supported"):
+            validate_sft_format(ds)
+
+    def test_sft_missing_tool_response_rejected(self):
+        from leap_finetune.data_loading.validate_dataset_format import (
+            validate_sft_format,
+        )
+
+        ds = Dataset.from_list(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "Get weather"},
+                        {
+                            "role": "assistant",
+                            "content": '<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>',
+                        },
+                        {"role": "user", "content": "Thanks"},
+                    ]
+                }
+            ]
+        )
+        with pytest.raises(ValueError, match="no tool response"):
+            validate_sft_format(ds)
+
+    # --- DPO ---
+
+    def test_dpo_foreign_markers_rejected(self):
+        from leap_finetune.data_loading.validate_dataset_format import (
+            validate_dpo_format,
+        )
+
+        # String format
+        ds = Dataset.from_list(
+            [{"chosen": "<tool_call>foo</tool_call>", "rejected": "no tools"}]
+        )
+        with pytest.raises(ValueError, match="Qwen"):
+            validate_dpo_format(ds)
+
+        # Message list format
+        ds = Dataset.from_list(
+            [
+                {
+                    "chosen": [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "<tool_call>foo</tool_call>"},
+                    ],
+                    "rejected": [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "No tools."},
+                    ],
+                }
+            ]
+        )
+        with pytest.raises(ValueError, match="Qwen"):
+            validate_dpo_format(ds)
+
+    def test_dpo_text_before_tool_call_rejected(self):
+        from leap_finetune.data_loading.validate_dataset_format import (
+            validate_dpo_format,
+        )
+
+        ds = Dataset.from_list(
+            [
+                {
+                    "chosen": 'Sure!\n<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>',
+                    "rejected": "I can't do that.",
+                }
+            ]
+        )
+        with pytest.raises(ValueError, match="Text appears before tool call"):
+            validate_dpo_format(ds)
+
+    # --- Row filters ---
+
+    def test_sft_row_filter_rejects_bad_tool_calls(self):
+        from leap_finetune.data_loading.validate_dataset_format import get_row_filter
+
+        f = get_row_filter("sft")
+        assert (
+            f(
+                {
+                    "messages": [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "<tool_call>x</tool_call>"},
+                    ]
+                }
+            )
+            is False
+        )
+        assert (
+            f(
+                {
+                    "messages": [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "ok", "tool_calls": [{}]},
+                    ]
+                }
+            )
+            is False
+        )
+
+    def test_dpo_row_filter_rejects_foreign_markers(self):
+        from leap_finetune.data_loading.validate_dataset_format import get_row_filter
+
+        f = get_row_filter("dpo")
+        assert f({"chosen": "<tool_call>x</tool_call>", "rejected": "no"}) is False
+
+    # --- Regression ---
+
+    def test_non_tool_call_data_unaffected(self):
+        from leap_finetune.data_loading.validate_dataset_format import (
+            validate_dpo_format,
+            validate_sft_format,
+        )
+
+        sft = Dataset.from_list(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "Hello!"},
+                    ]
+                }
+            ]
+        )
+        assert len(validate_sft_format(sft)) == 1
+
+        dpo = Dataset.from_list(
+            [
+                {
+                    "chosen": [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "Hello!"},
+                    ],
+                    "rejected": [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "Hey."},
+                    ],
+                }
+            ]
+        )
+        assert len(validate_dpo_format(dpo)) == 1
+
+
+# === DatasetLoader construction ===
+
+
+class TestDatasetLoader:
+    def test_invalid_test_size_zero_raises(self):
+        from leap_finetune.data_loading.dataset_loader import DatasetLoader
+
+        with pytest.raises(ValueError, match="test_size must be between"):
+            DatasetLoader(dataset_path="x", dataset_type="sft", test_size=0)
+
+    def test_invalid_test_size_above_one_raises(self):
+        from leap_finetune.data_loading.dataset_loader import DatasetLoader
+
+        with pytest.raises(ValueError, match="test_size must be between"):
+            DatasetLoader(dataset_path="x", dataset_type="sft", test_size=1.5)
+
+    def test_valid_construction(self):
+        from leap_finetune.data_loading.dataset_loader import DatasetLoader
+
+        loader = DatasetLoader(
+            dataset_path="HuggingFaceTB/smoltalk",
+            dataset_type="sft",
+            subset="all",
+            limit=20,
+        )
+        assert loader.dataset_type == "sft"
+        assert loader.limit == 20
+        assert loader.test_size == 0.2
+
+
+# === SFT tokenization ===
+
+
+class TestTokenizationSFT:
+    @pytest.fixture(scope="class")
+    def ray_session(self):
+        import ray
+
+        if not ray.is_initialized():
+            ray.init(address="local", num_cpus=2, runtime_env={"working_dir": None})
+        yield
+        ray.shutdown()
+
+    @pytest.fixture(scope="class")
+    def tokenizer(self):
+        from leap_finetune.checkpointing.model_loading import load_tokenizer
+
+        return load_tokenizer("LFM2-1.2B")
+
+    @pytest.fixture(scope="class")
+    def sft_datasets(self, ray_session, tokenizer):
+        from leap_finetune.data_loading.dataset_loader import DatasetLoader
+        from leap_finetune.data_loading.ray_data_utils import create_ray_datasets
+
+        loader = DatasetLoader(
+            dataset_path="HuggingFaceTB/smoltalk",
+            dataset_type="sft",
+            subset="all",
+            limit=50,
+        )
+        train_ds, eval_ds = create_ray_datasets(
+            loader,
+            tokenizer=tokenizer,
+            training_config={"max_length": 128, "packing": False},
+        )
+        return train_ds, eval_ds
+
+    def test_sft_tokenization_content(self, sft_datasets, tokenizer):
+        train_ds, _ = sft_datasets
+        row = next(iter(train_ds.iter_rows()))
+        assert "input_ids" in row
+        assert isinstance(row["input_ids"], list)
+        assert len(row["input_ids"]) > 0, "input_ids is empty"
+        assert all(isinstance(x, int) for x in row["input_ids"])
+
+        # All token IDs must be valid (within vocab range)
+        vocab_size = tokenizer.vocab_size
+        for token_id in row["input_ids"]:
+            assert 0 <= token_id < vocab_size, (
+                f"Token ID {token_id} out of vocab range [0, {vocab_size})"
+            )
+
+    def test_sft_tokenization_max_length_respected(self, sft_datasets):
+        train_ds, _ = sft_datasets
+        for row in train_ds.iter_rows():
+            assert len(row["input_ids"]) <= 128
+
+    def test_sft_train_eval_split(self, sft_datasets):
+        train_ds, eval_ds = sft_datasets
+        train_count = train_ds.count()
+        eval_count = eval_ds.count()
+        assert train_count > 0, "Train dataset is empty"
+        assert eval_count > 0, "Eval dataset is empty"
+        # test_size=0.2 → eval should be ~20% of total
+        total = train_count + eval_count
+        eval_ratio = eval_count / total
+        assert 0.1 < eval_ratio < 0.4, (
+            f"Eval ratio {eval_ratio:.2f} is outside expected range for test_size=0.2"
+        )
+
+    def test_sft_packing_changes_row_count(self, ray_session, tokenizer):
+        from leap_finetune.data_loading.dataset_loader import DatasetLoader
+        from leap_finetune.data_loading.ray_data_utils import create_ray_datasets
+
+        loader = DatasetLoader(
+            dataset_path="HuggingFaceTB/smoltalk",
+            dataset_type="sft",
+            subset="all",
+            limit=50,
+        )
+        train_unpacked, _ = create_ray_datasets(
+            loader,
+            tokenizer=tokenizer,
+            training_config={"max_length": 2048, "packing": False},
+        )
+        train_packed, _ = create_ray_datasets(
+            loader,
+            tokenizer=tokenizer,
+            training_config={"max_length": 2048, "packing": True},
+        )
+        unpacked_count = train_unpacked.count()
+        packed_count = train_packed.count()
+        assert packed_count < unpacked_count, (
+            f"Packing should reduce row count by combining short samples, "
+            f"but got packed={packed_count} >= unpacked={unpacked_count}"
+        )
+
+
+# === DPO tokenization ===
+
+
+class TestTokenizationDPO:
+    @pytest.fixture(scope="class")
+    def ray_session(self):
+        import ray
+
+        if not ray.is_initialized():
+            ray.init(address="local", num_cpus=2, runtime_env={"working_dir": None})
+        yield
+        ray.shutdown()
+
+    @pytest.fixture(scope="class")
+    def tokenizer(self):
+        from leap_finetune.checkpointing.model_loading import load_tokenizer
+
+        return load_tokenizer("LFM2-1.2B")
+
+    @pytest.fixture(scope="class")
+    def dpo_datasets(self, ray_session, tokenizer):
+        from leap_finetune.data_loading.dataset_loader import DatasetLoader
+        from leap_finetune.data_loading.ray_data_utils import create_ray_datasets
+
+        loader = DatasetLoader(
+            dataset_path="mlabonne/orpo-dpo-mix-40k",
+            dataset_type="dpo",
+            subset="default",
+            limit=50,
+        )
+        train_ds, eval_ds = create_ray_datasets(
+            loader,
+            tokenizer=tokenizer,
+            training_config={},
+        )
+        return train_ds, eval_ds
+
+    def test_dpo_tokenization_content(self, dpo_datasets, tokenizer):
+        train_ds, _ = dpo_datasets
+        row = next(iter(train_ds.iter_rows()))
+        assert "prompt_ids" in row
+        assert "chosen_ids" in row
+        assert "rejected_ids" in row
+
+        # All sequences must be non-empty
+        assert len(row["prompt_ids"]) > 0, "prompt_ids is empty"
+        assert len(row["chosen_ids"]) > 0, "chosen_ids is empty"
+        assert len(row["rejected_ids"]) > 0, "rejected_ids is empty"
+
+        # Chosen and rejected must differ (otherwise DPO is meaningless)
+        assert row["chosen_ids"] != row["rejected_ids"], (
+            "chosen and rejected have identical token IDs"
+        )
+
+        # All token IDs must be within vocab range
+        vocab_size = tokenizer.vocab_size
+        for name in ("prompt_ids", "chosen_ids", "rejected_ids"):
+            for token_id in row[name]:
+                assert 0 <= token_id < vocab_size, (
+                    f"{name} has token ID {token_id} out of vocab range [0, {vocab_size})"
+                )
+
+    def test_dpo_eos_appended(self, dpo_datasets, tokenizer):
+        train_ds, _ = dpo_datasets
+        eos_id = tokenizer.eos_token_id
+        # Check multiple rows, not just the first
+        for i, row in enumerate(train_ds.iter_rows()):
+            assert row["chosen_ids"][-1] == eos_id, f"Row {i}: chosen missing EOS token"
+            assert row["rejected_ids"][-1] == eos_id, (
+                f"Row {i}: rejected missing EOS token"
+            )
+            if i >= 9:
+                break
+
+
+# === Sharding correctness ===
+
+
+class TestShardingCorrectness:
+    @pytest.fixture(scope="class")
+    def ray_session(self):
+        import ray
+
+        if not ray.is_initialized():
+            ray.init(address="local", num_cpus=2, runtime_env={"working_dir": None})
+        yield
+        ray.shutdown()
+
+    @pytest.fixture(scope="class")
+    def tokenizer(self):
+        from leap_finetune.checkpointing.model_loading import load_tokenizer
+
+        return load_tokenizer("LFM2-1.2B")
+
+    @pytest.fixture(scope="class")
+    def tokenized_train_ds(self, ray_session, tokenizer):
+        from leap_finetune.data_loading.dataset_loader import DatasetLoader
+        from leap_finetune.data_loading.ray_data_utils import create_ray_datasets
+
+        loader = DatasetLoader(
+            dataset_path="HuggingFaceTB/smoltalk",
+            dataset_type="sft",
+            subset="all",
+            limit=100,
+        )
+        train_ds, _ = create_ray_datasets(
+            loader,
+            tokenizer=tokenizer,
+            training_config={"max_length": 128, "packing": False},
+        )
+        return train_ds
+
+    def test_no_duplicate_rows_across_shards(self, tokenized_train_ds):
+        shards = tokenized_train_ds.split(2, equal=True)
+        shard_0_ids = [tuple(row["input_ids"]) for row in shards[0].iter_rows()]
+        shard_1_ids = [tuple(row["input_ids"]) for row in shards[1].iter_rows()]
+        overlap = set(shard_0_ids) & set(shard_1_ids)
+        assert len(overlap) == 0, f"Found {len(overlap)} duplicate rows across shards"
+
+    def test_shard_sizes_roughly_equal(self, tokenized_train_ds):
+        shards = tokenized_train_ds.split(2, equal=True)
+        sizes = [shard.count() for shard in shards]
+        assert abs(sizes[0] - sizes[1]) <= 1
+
+
+# === Custom trainer DataLoader bypass ===
+
+
+class TestCustomTrainerDataLoaders:
+    def test_lfm_sft_trainer_no_distributed_sampler(self):
+        from datasets import Dataset
+        from torch.utils.data import DistributedSampler
+        from transformers import AutoConfig, AutoModelForCausalLM, TrainingArguments
+
+        from leap_finetune.training.sft import LFMSFTTrainer
+
+        dummy_dataset = Dataset.from_dict(
+            {"input_ids": [[1, 2, 3]], "attention_mask": [[1, 1, 1]]}
+        )
+        args = TrainingArguments(
+            output_dir="/tmp/test_sft",
+            per_device_train_batch_size=1,
+            report_to="none",
+            use_cpu=True,
+        )
+        config = AutoConfig.from_pretrained("LiquidAI/LFM2-1.2B")
+        model = AutoModelForCausalLM.from_config(config)
+        trainer = LFMSFTTrainer(
+            model=model,
+            args=args,
+            train_dataset=dummy_dataset,
+            data_collator=lambda x: x,
+        )
+        dl = trainer.get_train_dataloader()
+        assert not isinstance(dl.sampler, DistributedSampler)
+
+    def test_lfm_dpo_trainer_skips_prepare_dataset(self):
+        from datasets import Dataset
+
+        from leap_finetune.training.dpo import LFMDPOTrainer
+
+        dummy = Dataset.from_dict({"a": [1, 2, 3]})
+        result = LFMDPOTrainer._prepare_dataset(None, dummy)
+        assert result is dummy

--- a/tests/test_dense_e2e.py
+++ b/tests/test_dense_e2e.py
@@ -1,0 +1,60 @@
+import pytest
+
+from conftest import (
+    assert_checkpoints_exist,
+    assert_training_result,
+    requires_gpu,
+    run_e2e_training,
+)
+
+pytestmark = pytest.mark.dense
+
+FIXTURES = __import__("pathlib").Path(__file__).parent / "fixtures"
+
+
+# === Dense SFT with LoRA ===
+
+
+class TestDenseSFTLoRA:
+    @requires_gpu
+    def test_training_completes_and_learns(self, e2e_output_dir):
+        config_path = str(FIXTURES / "e2e_sft_lora.yaml")
+        result = run_e2e_training(config_path, e2e_output_dir)
+        assert_training_result(result, max_eval_loss=7.0, check_loss_trend=False)
+
+
+# === Dense SFT full fine-tune ===
+
+
+class TestDenseSFTFull:
+    @requires_gpu
+    def test_training_completes_learns_and_checkpoints(self, e2e_output_dir):
+        config_path = str(FIXTURES / "e2e_sft_full.yaml")
+        result = run_e2e_training(config_path, e2e_output_dir)
+        assert_training_result(result)
+
+        assert_checkpoints_exist(e2e_output_dir)
+
+
+# === Dense DPO with LoRA ===
+
+
+class TestDenseDPOLoRA:
+    @requires_gpu
+    def test_training_completes_and_learns(self, e2e_output_dir):
+        config_path = str(FIXTURES / "e2e_dpo_lora.yaml")
+        result = run_e2e_training(config_path, e2e_output_dir)
+        assert_training_result(result, check_loss_trend=False)
+
+
+# === Dense DPO full fine-tune ===
+
+
+class TestDenseDPOFull:
+    @requires_gpu
+    def test_training_completes_learns_and_checkpoints(self, e2e_output_dir):
+        config_path = str(FIXTURES / "e2e_dpo_full.yaml")
+        result = run_e2e_training(config_path, e2e_output_dir)
+        assert_training_result(result, check_loss_trend=False)
+
+        assert_checkpoints_exist(e2e_output_dir)

--- a/tests/test_grpo_config.py
+++ b/tests/test_grpo_config.py
@@ -1,0 +1,284 @@
+import pytest
+
+from leap_finetune.rl.rewards import resolve_reward_specs
+from leap_finetune.config import parse_job_config
+from leap_finetune.training.default_configs import TrainingConfig
+
+from conftest import write_config
+
+pytestmark = pytest.mark.configs
+
+
+# === Shared fixtures ===
+
+
+GRPO_DATASET = {
+    "path": "trl-lib/DeepMath-103K",
+    "type": "grpo",
+    "limit": 10,
+}
+
+VLM_GRPO_DATASET = {
+    "path": "alay2shah/example-vlm-sft-dataset",
+    "type": "vlm_grpo",
+    "limit": 10,
+    "image_root": "/tmp/images",
+}
+
+
+# === Base config auto-discovery ===
+
+
+class TestGRPOBaseConfigDiscovery:
+    def test_default_grpo_discovered(self):
+        assert "DEFAULT_GRPO" in {m.name for m in TrainingConfig}
+
+    def test_default_vlm_grpo_discovered(self):
+        assert "DEFAULT_VLM_GRPO" in {m.name for m in TrainingConfig}
+
+    def test_moe_grpo_discovered(self):
+        assert "MOE_GRPO" in {m.name for m in TrainingConfig}
+
+    def test_default_grpo_has_trl_v1_fields(self):
+        cfg = TrainingConfig.DEFAULT_GRPO.value
+        assert cfg["training_type"] == "grpo"
+        assert cfg["loss_type"] == "dapo"  # TRL v1 default
+        assert cfg["beta"] == 0.0  # KL off by default
+        assert cfg["vllm_mode"] == "colocate"
+        assert cfg["use_vllm"] is True
+        assert cfg["num_generations"] == 8
+
+    def test_default_vlm_grpo_has_correct_training_type(self):
+        cfg = TrainingConfig.DEFAULT_VLM_GRPO.value
+        assert cfg["training_type"] == "vlm_grpo"
+        assert cfg["num_generations"] == 4  # smaller groups for VLM memory
+        assert "lr_multipliers" in cfg
+        assert cfg["lr_multipliers"]["model.vision_tower"] == 0.1
+
+
+# === Basic parse ===
+
+
+class TestParseGRPOConfig:
+    def test_minimal_grpo_config(self, tmp_path):
+        config = {
+            "project_name": "test_grpo",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": GRPO_DATASET,
+            "training_config": {"extends": "DEFAULT_GRPO"},
+            "rewards": {
+                "funcs": ["./rewards/length.py::length_reward"],
+                "weights": [1.0],
+            },
+        }
+        jc = parse_job_config(write_config(config, tmp_path))
+        assert jc.training_type == "grpo"
+        # Paths are pre-resolved to absolute by config_parser so Ray workers
+        # (whose CWD is a sandbox) can find the reward files.
+        assert len(jc.rewards["funcs"]) == 1
+        assert jc.rewards["funcs"][0].endswith("rewards/length.py::length_reward")
+        assert jc.rewards["weights"] == [1.0]
+        assert jc.rl_env is None
+        assert jc.grpo_rollout is None
+        assert jc.config_dir == str(tmp_path.resolve())
+
+    def test_config_relative_custom_reward_path_is_absolutized(self, tmp_path):
+        reward_file = tmp_path / "local_reward.py"
+        reward_file.write_text(
+            "def local_reward(completions, **kwargs):\n"
+            "    return [1.0 for _ in completions]\n"
+        )
+        config = {
+            "project_name": "test_grpo",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": GRPO_DATASET,
+            "training_config": {"extends": "DEFAULT_GRPO"},
+            "rewards": {
+                "funcs": ["./local_reward.py::local_reward"],
+                "weights": [1.0],
+            },
+        }
+        jc = parse_job_config(write_config(config, tmp_path))
+
+        assert jc.rewards["funcs"] == [f"{reward_file.resolve()}::local_reward"]
+
+    def test_grpo_defaults_test_size_to_tiny(self, tmp_path):
+        """GRPO is online so it doesn't need offline eval. We default test_size
+        to 0.01 to keep the ray pipeline happy without wasting data."""
+        config = {
+            "project_name": "t",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": {"path": "trl-lib/DeepMath-103K", "type": "grpo"},
+            "rewards": ["./rewards/length.py::length_reward"],
+        }
+        jc = parse_job_config(write_config(config, tmp_path))
+        assert jc.dataset.test_size == 0.01
+
+    def test_grpo_override_persists(self, tmp_path):
+        config = {
+            "project_name": "t",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": GRPO_DATASET,
+            "training_config": {
+                "extends": "DEFAULT_GRPO",
+                "num_generations": 4,
+                "learning_rate": 5e-7,
+            },
+            "rewards": ["./rewards/length.py::length_reward"],
+        }
+        jc = parse_job_config(write_config(config, tmp_path))
+        cfg = jc.training_config.value
+        assert cfg["num_generations"] == 4
+        assert cfg["learning_rate"] == 5e-7
+        # Inherited defaults still there
+        assert cfg["loss_type"] == "dapo"
+        assert cfg["vllm_mode"] == "colocate"
+
+    def test_grpo_judge_reward_config_persists(self, tmp_path):
+        config = {
+            "project_name": "t",
+            "model_name": "LFM2-1.2B",
+            "training_type": "grpo",
+            "dataset": GRPO_DATASET,
+            "training_config": {"extends": "DEFAULT_GRPO"},
+            "rewards": {
+                "judge": {
+                    "model": "LFM2-1.2B",
+                    "base_url": "http://judge:8001",
+                    "weight": 0.5,
+                }
+            },
+        }
+        jc = parse_job_config(write_config(config, tmp_path))
+        assert jc.rewards["judge"]["model"] == "LFM2-1.2B"
+        funcs, weights = resolve_reward_specs(jc.rewards, tmp_path)
+        assert [f.__name__ for f in funcs] == ["judge_llm_reward"]
+        assert weights == [0.5]
+
+
+# === VLM GRPO ===
+
+
+class TestParseVLMGRPOConfig:
+    def test_full_vlm_grpo_with_rl_env_and_rollout(self, tmp_path):
+        config = {
+            "project_name": "vlm_grpo_test",
+            "model_name": "LFM2-VL-1.6B",
+            "training_type": "vlm_grpo",
+            "dataset": VLM_GRPO_DATASET,
+            "training_config": {"extends": "DEFAULT_VLM_GRPO"},
+            "rl_env": {
+                "source": "liquidai/vlm-grounding-bbox-env",
+                "max_turns": 1,
+            },
+            "grpo_rollout": {
+                "server_gpus": 1,
+                "tensor_parallel_size": 1,
+                "dtype": "bfloat16",
+            },
+            "rewards": {
+                "funcs": ["./rewards/length.py::length_reward"],
+                "weights": [0.2],
+            },
+        }
+        jc = parse_job_config(write_config(config, tmp_path))
+        assert jc.training_type == "vlm_grpo"
+        assert jc.rl_env["source"] == "liquidai/vlm-grounding-bbox-env"
+        assert jc.grpo_rollout["server_gpus"] == 1
+        # Per-component LR multipliers come through
+        cfg = jc.training_config.value
+        assert "lr_multipliers" in cfg
+        assert cfg["lr_multipliers"]["model.vision_tower"] == 0.1
+        assert cfg["training_type"] == "vlm_grpo"
+
+    def test_vision_encoder_lr_multiplier_override(self, tmp_path):
+        config = {
+            "project_name": "t",
+            "model_name": "LFM2-VL-1.6B",
+            "training_type": "vlm_grpo",
+            "dataset": VLM_GRPO_DATASET,
+            "training_config": {
+                "extends": "DEFAULT_VLM_GRPO",
+                "vision_encoder_lr_multiplier": 0.05,
+            },
+            "rewards": ["./rewards/length.py::length_reward"],
+        }
+        jc = parse_job_config(write_config(config, tmp_path))
+        assert jc.training_config.value["vision_encoder_lr_multiplier"] == 0.05
+
+
+# === Rejection of GRPO keys on non-GRPO runs ===
+
+
+class TestGRPOKeysRejectedOnNonGRPO:
+    def test_rewards_on_sft_rejected(self, tmp_path):
+        config = {
+            "project_name": "t",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": {"path": "x", "type": "sft"},
+            "rewards": ["./rewards/length.py::length_reward"],
+        }
+        with pytest.raises((ValueError, Exception), match="grpo"):
+            parse_job_config(write_config(config, tmp_path))
+
+    def test_rl_env_on_dpo_rejected(self, tmp_path):
+        config = {
+            "project_name": "t",
+            "model_name": "LFM2-1.2B",
+            "training_type": "dpo",
+            "dataset": {"path": "x", "type": "dpo"},
+            "rl_env": {"source": "qgallouedec/echo_env"},
+        }
+        with pytest.raises((ValueError, Exception), match="grpo"):
+            parse_job_config(write_config(config, tmp_path))
+
+    def test_grpo_rollout_on_vlm_sft_rejected(self, tmp_path):
+        config = {
+            "project_name": "t",
+            "model_name": "LFM2-VL-1.6B",
+            "training_type": "vlm_sft",
+            "dataset": {"path": "x", "type": "vlm_sft"},
+            "grpo_rollout": {"server_gpus": 1},
+        }
+        with pytest.raises((ValueError, Exception), match="grpo"):
+            parse_job_config(write_config(config, tmp_path))
+
+
+# === Shipped example YAMLs ===
+
+
+class TestShippedExampleConfigs:
+    """The example YAMLs in job_configs/ must all parse cleanly."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "grpo_example.yaml",
+            "grpo_server_mode_example.yaml",
+            "vlm_grpo_grounding_example.yaml",
+        ],
+    )
+    def test_example_parses(self, filename, job_configs_dir):
+        path = str(job_configs_dir / filename)
+        jc = parse_job_config(path)
+        assert jc.training_type in ("grpo", "vlm_grpo")
+        resolve_reward_specs(jc.rewards, job_configs_dir)
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "e2e_grpo.yaml",
+            "e2e_vlm_grpo.yaml",
+        ],
+    )
+    def test_grpo_smoke_fixtures_keep_vllm_enabled(self, filename, fixtures_dir):
+        path = str(fixtures_dir / filename)
+        jc = parse_job_config(path)
+        assert jc.training_type in ("grpo", "vlm_grpo")
+        assert jc.training_config.value["use_vllm"] is True
+        assert jc.training_config.value["vllm_mode"] == "colocate"

--- a/tests/test_grpo_config.py
+++ b/tests/test_grpo_config.py
@@ -1,12 +1,19 @@
 import pytest
 
 from leap_finetune.rl.rewards import resolve_reward_specs
-from leap_finetune.config import parse_job_config
-from leap_finetune.training.default_configs import TrainingConfig
+from leap_finetune.config import (
+    materialize_job_config,
+    parse_job_config as _parse_job_config,
+)
+from leap_finetune.training.default_configs import TRAINING_DEFAULTS
 
 from conftest import write_config
 
 pytestmark = pytest.mark.configs
+
+
+def parse_job_config(config_input):
+    return materialize_job_config(_parse_job_config(config_input))
 
 
 # === Shared fixtures ===
@@ -31,16 +38,16 @@ VLM_GRPO_DATASET = {
 
 class TestGRPOBaseConfigDiscovery:
     def test_default_grpo_discovered(self):
-        assert "DEFAULT_GRPO" in {m.name for m in TrainingConfig}
+        assert "DEFAULT_GRPO" in TRAINING_DEFAULTS
 
     def test_default_vlm_grpo_discovered(self):
-        assert "DEFAULT_VLM_GRPO" in {m.name for m in TrainingConfig}
+        assert "DEFAULT_VLM_GRPO" in TRAINING_DEFAULTS
 
     def test_moe_grpo_discovered(self):
-        assert "MOE_GRPO" in {m.name for m in TrainingConfig}
+        assert "MOE_GRPO" in TRAINING_DEFAULTS
 
     def test_default_grpo_has_trl_v1_fields(self):
-        cfg = TrainingConfig.DEFAULT_GRPO.value
+        cfg = TRAINING_DEFAULTS["DEFAULT_GRPO"]
         assert cfg["training_type"] == "grpo"
         assert cfg["loss_type"] == "dapo"  # TRL v1 default
         assert cfg["beta"] == 0.0  # KL off by default
@@ -49,7 +56,7 @@ class TestGRPOBaseConfigDiscovery:
         assert cfg["num_generations"] == 8
 
     def test_default_vlm_grpo_has_correct_training_type(self):
-        cfg = TrainingConfig.DEFAULT_VLM_GRPO.value
+        cfg = TRAINING_DEFAULTS["DEFAULT_VLM_GRPO"]
         assert cfg["training_type"] == "vlm_grpo"
         assert cfg["num_generations"] == 4  # smaller groups for VLM memory
         assert "lr_multipliers" in cfg

--- a/tests/test_hf_export_metadata.py
+++ b/tests/test_hf_export_metadata.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from leap_finetune.checkpointing.hf_export import (
+    HF_EXPORT_MAX_SHARD_SIZE,
+    _canonicalize_hf_export_state_dict,
+    _reassemble_ep_expert_state_dict,
+    _save_hf_pretrained_model,
+    _save_root_hf_export,
+)
+from leap_finetune.checkpointing.manual_sharded import (
+    MANUAL_SHARDED_FORMAT_VERSION,
+    _save_root_metadata,
+    build_manual_sharded_export_metadata_from_config,
+    finalize_manual_sharded_export_metadata,
+    load_manual_sharded_checkpoint_metadata,
+)
+from leap_finetune.checkpointing.model_loading import normalize_model_config_overrides
+
+
+class ConfigStub:
+    auto_map = {
+        "AutoConfig": "configuration_lfm2_moe.Lfm2MoeConfig",
+        "AutoModelForCausalLM": "modeling_lfm2_moe.Lfm2MoeForCausalLM",
+    }
+
+    def __init__(self, source_dir: Path):
+        self._name_or_path = str(source_dir)
+        self.model_type = "lfm2_moe"
+        self.max_position_embeddings = 131072
+        self.rope_parameters = {"rope_type": "default", "rope_theta": 1000000.0}
+        self.rope_scaling = None
+        self.rope_theta = 1000000.0
+        self.default_theta = 1000000.0
+        self.tie_word_embeddings = True
+
+    def save_pretrained(self, output_dir: str) -> None:
+        config = {
+            "model_type": self.model_type,
+            "auto_map": self.auto_map,
+            "max_position_embeddings": self.max_position_embeddings,
+            "rope_parameters": self.rope_parameters,
+            "rope_theta": self.rope_theta,
+            "tie_word_embeddings": self.tie_word_embeddings,
+        }
+        if self.rope_scaling is not None:
+            config["rope_scaling"] = self.rope_scaling
+        Path(output_dir, "config.json").write_text(json.dumps(config))
+
+
+class GenerationConfigStub:
+    def save_pretrained(self, output_dir: str) -> None:
+        Path(output_dir, "generation_config.json").write_text(
+            json.dumps({"eos_token_id": 7})
+        )
+
+
+class ModelStub:
+    def __init__(self, source_dir: Path):
+        self.config = ConfigStub(source_dir)
+        self.generation_config = GenerationConfigStub()
+        self.saved_state_dict = None
+        self.saved_kwargs = None
+
+    def save_pretrained(self, output_dir: str, **kwargs) -> None:
+        self.saved_state_dict = kwargs.pop("state_dict")
+        self.saved_kwargs = kwargs
+        self.config.save_pretrained(output_dir)
+        self.generation_config.save_pretrained(output_dir)
+        Path(output_dir, "model.safetensors").write_bytes(b"weights")
+
+
+class AliasedRopeConfigStub:
+    auto_map = {}
+
+    def __init__(self):
+        self.model_type = "lfm2_moe"
+        self.max_position_embeddings = 128000
+        self.rope_parameters = {"rope_type": "default", "rope_theta": 1000000.0}
+        self.default_theta = 1000000.0
+        self.tie_word_embeddings = True
+
+    @property
+    def rope_scaling(self):
+        return self.rope_parameters
+
+    @rope_scaling.setter
+    def rope_scaling(self, value):
+        self.rope_parameters = value
+
+    def save_pretrained(self, output_dir: str) -> None:
+        config = {
+            "model_type": self.model_type,
+            "max_position_embeddings": self.max_position_embeddings,
+            "rope_parameters": self.rope_parameters,
+            "tie_word_embeddings": self.tie_word_embeddings,
+        }
+        if "rope_scaling" in self.__dict__:
+            config["rope_scaling"] = self.__dict__["rope_scaling"]
+        Path(output_dir, "config.json").write_text(json.dumps(config))
+
+
+class AliasedRopeModelStub(ModelStub):
+    def __init__(self):
+        self.config = AliasedRopeConfigStub()
+        self.generation_config = GenerationConfigStub()
+        self.saved_state_dict = None
+        self.saved_kwargs = None
+
+
+class AcceleratorStub:
+    def __init__(self, unwrapped_model):
+        self.unwrapped_model = unwrapped_model
+
+    def unwrap_model(self, model, keep_torch_compile=False):
+        del model, keep_torch_compile
+        return self.unwrapped_model
+
+
+class TokenizerStub:
+    chat_template = "template-v1"
+
+
+def test_manual_sharded_metadata_preserves_run_config_and_active_template():
+    training_config = {
+        "model_name": "LiquidAI/LFM2-24B-A2B",
+        "model_config": {
+            "rope_scaling": {"rope_type": "yarn", "factor": 10.0},
+        },
+        "train_config": {
+            "max_length": 327680,
+            "chat_template_path": "job_configs/chat_templates/lfm.jinja",
+        },
+    }
+
+    metadata = build_manual_sharded_export_metadata_from_config(
+        training_config,
+        processing_class=TokenizerStub(),
+    )
+
+    assert metadata["training_config"] == training_config
+    assert metadata["base_model_name"] == "LiquidAI/LFM2-24B-A2B"
+    assert metadata["model_config"] == training_config["model_config"]
+    assert metadata["max_length"] == 327680
+    assert metadata["chat_template"] == "template-v1"
+    assert len(metadata["chat_template_sha256"]) == 64
+
+
+def test_root_metadata_records_checkpoint_contract(tmp_path: Path):
+    _save_root_metadata(
+        str(tmp_path),
+        save_only_model=False,
+        checkpoint_format="both",
+        export_metadata={
+            "base_model_name": "LiquidAI/LFM2-24B-A2B",
+            "max_length": 327680,
+        },
+    )
+
+    metadata = load_manual_sharded_checkpoint_metadata(str(tmp_path))
+    assert metadata["format_version"] == MANUAL_SHARDED_FORMAT_VERSION
+    assert metadata["checkpoint_format"] == "both"
+    assert metadata["has_resume_state"] is True
+    assert metadata["has_optimizer_state"] is True
+    assert metadata["base_model_name"] == "LiquidAI/LFM2-24B-A2B"
+    assert metadata["max_length"] == 327680
+
+
+def test_finalize_manual_sharded_metadata_uses_current_template():
+    metadata = finalize_manual_sharded_export_metadata(
+        {"chat_template": "stale", "base_model_name": "base"},
+        processing_class=TokenizerStub(),
+    )
+
+    assert metadata["base_model_name"] == "base"
+    assert metadata["chat_template"] == "template-v1"
+    assert len(metadata["chat_template_sha256"]) == 64
+
+
+def test_save_hf_pretrained_model_delegates_to_hf_and_copies_custom_code(
+    tmp_path: Path,
+):
+    source_dir = tmp_path / "base"
+    export_dir = tmp_path / "export"
+    source_dir.mkdir()
+    (source_dir / "configuration_lfm2_moe.py").write_text("# config code\n")
+    (source_dir / "modeling_lfm2_moe.py").write_text("# modeling code\n")
+    model = ModelStub(source_dir)
+    state_dict = {"model.embed_tokens.weight": torch.ones(2, 3)}
+
+    _save_hf_pretrained_model(
+        model_to_save=model,
+        state_dict=state_dict,
+        export_dir=str(export_dir),
+    )
+
+    config = json.loads((export_dir / "config.json").read_text())
+    generation_config = json.loads((export_dir / "generation_config.json").read_text())
+
+    assert model.saved_state_dict is state_dict
+    assert model.saved_kwargs["is_main_process"] is True
+    assert model.saved_kwargs["max_shard_size"] == HF_EXPORT_MAX_SHARD_SIZE
+    assert config["model_type"] == "lfm2_moe"
+    assert config["max_position_embeddings"] == 131072
+    assert config["tie_word_embeddings"] is True
+    assert generation_config["eos_token_id"] == 7
+    assert (export_dir / "model.safetensors").read_bytes() == b"weights"
+    assert (export_dir / "configuration_lfm2_moe.py").read_text() == "# config code\n"
+    assert (export_dir / "modeling_lfm2_moe.py").read_text() == "# modeling code\n"
+
+
+def test_save_hf_pretrained_model_preserves_yarn_and_tied_lm_head_contract(
+    tmp_path: Path,
+):
+    source_dir = tmp_path / "base"
+    export_dir = tmp_path / "export"
+    source_dir.mkdir()
+    model = ModelStub(source_dir)
+    state_dict = {
+        "model.embed_tokens.weight": torch.ones(2, 3),
+        "lm_head.weight": torch.ones(2, 3),
+    }
+
+    _save_hf_pretrained_model(
+        model_to_save=model,
+        state_dict=state_dict,
+        export_dir=str(export_dir),
+        export_metadata={
+            "model_config": {
+                "rope_scaling": {
+                    "rope_type": "yarn",
+                    "factor": 10.0,
+                    "original_max_position_embeddings": 128000,
+                },
+                "max_position_embeddings": 327680,
+            },
+            "max_length": 327680,
+        },
+    )
+
+    config = json.loads((export_dir / "config.json").read_text())
+    assert config["max_position_embeddings"] == 327680
+    assert config["rope_parameters"]["rope_type"] == "yarn"
+    assert config["rope_parameters"]["factor"] == 10.0
+    assert config["rope_parameters"]["original_max_position_embeddings"] == 128000
+    assert config["rope_parameters"]["rope_theta"] == 1000000.0
+    assert config["rope_scaling"]["type"] == "yarn"
+    assert config["rope_scaling"]["factor"] == 10.0
+    assert config["rope_scaling"]["original_max_position_embeddings"] == 128000
+    assert config["tie_word_embeddings"] is True
+    assert "lm_head.weight" not in model.saved_state_dict
+
+
+def test_lfm2_rope_theta_override_is_mirrored_to_rope_parameters():
+    config = ConfigStub(Path("base"))
+
+    normalized = normalize_model_config_overrides(
+        config,
+        {"rope_theta": 5000000.0},
+    )
+
+    assert normalized["rope_theta"] == 5000000.0
+    assert normalized["rope_parameters"]["rope_theta"] == 5000000.0
+    assert normalized["rope_parameters"]["rope_type"] == "default"
+
+
+@pytest.mark.parametrize("override_key", ["tie_word_embeddings", "tie_embedding"])
+def test_lfm2_tie_embedding_false_override_is_rejected(override_key: str):
+    config = ConfigStub(Path("base"))
+
+    with pytest.raises(ValueError, match="require tied word embeddings"):
+        normalize_model_config_overrides(config, {override_key: False})
+
+
+def test_save_hf_pretrained_model_preserves_rope_theta_without_yarn(
+    tmp_path: Path,
+):
+    source_dir = tmp_path / "base"
+    export_dir = tmp_path / "export"
+    source_dir.mkdir()
+    model = ModelStub(source_dir)
+
+    _save_hf_pretrained_model(
+        model_to_save=model,
+        state_dict={"model.embed_tokens.weight": torch.ones(2, 3)},
+        export_dir=str(export_dir),
+        export_metadata={
+            "model_config": {
+                "rope_theta": 5000000.0,
+                "max_position_embeddings": 327680,
+            },
+            "max_length": 327680,
+        },
+    )
+
+    config = json.loads((export_dir / "config.json").read_text())
+    assert config["max_position_embeddings"] == 327680
+    assert config["rope_theta"] == 5000000.0
+    assert config["rope_parameters"]["rope_theta"] == 5000000.0
+    assert config["rope_parameters"]["rope_type"] == "default"
+
+
+def test_save_hf_pretrained_model_writes_literal_rope_scaling_key_for_alias_config(
+    tmp_path: Path,
+):
+    export_dir = tmp_path / "export"
+    model = AliasedRopeModelStub()
+
+    _save_hf_pretrained_model(
+        model_to_save=model,
+        state_dict={"model.embed_tokens.weight": torch.ones(2, 3)},
+        export_dir=str(export_dir),
+        export_metadata={
+            "model_config": {
+                "rope_scaling": {
+                    "rope_type": "yarn",
+                    "factor": 10.0,
+                    "original_max_position_embeddings": 128000,
+                },
+            },
+            "max_length": 327680,
+        },
+    )
+
+    config = json.loads((export_dir / "config.json").read_text())
+    assert config["rope_parameters"]["rope_type"] == "yarn"
+    assert config["rope_scaling"]["type"] == "yarn"
+    assert config["rope_scaling"]["rope_type"] == "yarn"
+    assert config["rope_scaling"]["factor"] == 10.0
+
+
+def test_canonicalize_hf_export_state_dict_unpacks_lfm2_moe_experts():
+    gate_up = torch.arange(2 * 4 * 3).reshape(2, 4, 3)
+    down = torch.arange(100, 100 + 2 * 3 * 2).reshape(2, 3, 2)
+
+    canonical = _canonicalize_hf_export_state_dict(
+        {
+            "model.layers.2.feed_forward.experts.gate_up_proj": gate_up,
+            "model.layers.2.feed_forward.experts.down_proj": down,
+            "model.layers.2.feed_forward.gate.weight": torch.ones(2, 3),
+        }
+    )
+
+    assert "model.layers.2.feed_forward.experts.gate_up_proj" not in canonical
+    assert "model.layers.2.feed_forward.experts.down_proj" not in canonical
+    assert torch.equal(
+        canonical["model.layers.2.feed_forward.experts.0.w1.weight"],
+        gate_up[0, :2],
+    )
+    assert torch.equal(
+        canonical["model.layers.2.feed_forward.experts.0.w3.weight"],
+        gate_up[0, 2:],
+    )
+    assert torch.equal(
+        canonical["model.layers.2.feed_forward.experts.1.w2.weight"],
+        down[1],
+    )
+    assert torch.equal(
+        canonical["model.layers.2.feed_forward.gate.weight"],
+        torch.ones(2, 3),
+    )
+
+
+def test_reassemble_ep_expert_state_dict_restores_global_expert_axis(monkeypatch):
+    ep_group = object()
+    gate_up = torch.arange(2 * 4 * 3).reshape(2, 4, 3)
+    down = torch.arange(100, 100 + 2 * 3 * 2).reshape(2, 3, 2)
+    state_dict = {
+        "model.layers.2.feed_forward.experts.gate_up_proj": gate_up,
+        "model.layers.2.feed_forward.experts.down_proj": down,
+        "model.embed_tokens.weight": torch.ones(2, 3),
+    }
+
+    monkeypatch.setattr("leap_finetune.checkpointing.hf_export._global_rank", lambda: 0)
+    monkeypatch.setattr(
+        "leap_finetune.checkpointing.hf_export.dist.is_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "leap_finetune.checkpointing.hf_export.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr(
+        "leap_finetune.checkpointing.hf_export.dist.get_world_size",
+        lambda group: 2,
+    )
+
+    def fake_all_gather(gathered, local_value, group):
+        del group
+        if local_value.numel() == 1:
+            gathered[0].copy_(local_value)
+            gathered[1].copy_(local_value)
+        else:
+            gathered[0].copy_(local_value)
+            gathered[1].copy_(local_value + 1000)
+
+    monkeypatch.setattr(
+        "leap_finetune.checkpointing.hf_export.dist.all_gather",
+        fake_all_gather,
+    )
+
+    reassembled = _reassemble_ep_expert_state_dict(state_dict, ep_group)
+    full_gate_up = reassembled["model.layers.2.feed_forward.experts.gate_up_proj"]
+    full_down = reassembled["model.layers.2.feed_forward.experts.down_proj"]
+
+    assert full_gate_up.shape == (4, 4, 3)
+    assert full_down.shape == (4, 3, 2)
+    assert torch.equal(full_gate_up[:2], gate_up)
+    assert torch.equal(full_gate_up[2:], gate_up + 1000)
+    assert torch.equal(full_down[:2], down)
+    assert torch.equal(full_down[2:], down + 1000)
+    assert (
+        reassembled["model.embed_tokens.weight"]
+        is state_dict["model.embed_tokens.weight"]
+    )
+
+
+def test_root_hf_export_uses_full_state_dict_and_hf_save_pretrained(
+    tmp_path: Path,
+    monkeypatch,
+):
+    source_dir = tmp_path / "base"
+    source_dir.mkdir()
+    (source_dir / "configuration_lfm2_moe.py").write_text("# config code\n")
+    (source_dir / "modeling_lfm2_moe.py").write_text("# modeling code\n")
+    unwrapped_model = ModelStub(source_dir)
+    gate_up = torch.arange(2 * 4 * 3).reshape(2, 4, 3)
+    down = torch.arange(100, 100 + 2 * 3 * 2).reshape(2, 3, 2)
+    captured_options = []
+
+    def fake_get_model_state_dict(model, *, options):
+        captured_options.append(options)
+        return {
+            "model.layers.2.feed_forward.experts.gate_up_proj": gate_up,
+            "model.layers.2.feed_forward.experts.down_proj": down,
+        }
+
+    monkeypatch.setattr(
+        "leap_finetune.checkpointing.hf_export.get_model_state_dict",
+        fake_get_model_state_dict,
+    )
+    monkeypatch.setattr(
+        "leap_finetune.checkpointing.hf_export._world_barrier", lambda: None
+    )
+
+    _save_root_hf_export(
+        model=object(),
+        accelerator=AcceleratorStub(unwrapped_model),
+        output_dir=str(tmp_path / "export"),
+        processing_class=None,
+        data_collator=None,
+        training_args={"arg": "value"},
+        staging_dir=None,
+    )
+
+    assert len(captured_options) == 1
+    assert captured_options[0].full_state_dict is True
+    assert captured_options[0].cpu_offload is True
+    assert "model.layers.2.feed_forward.experts.gate_up_proj" not in (
+        unwrapped_model.saved_state_dict
+    )
+    assert torch.equal(
+        unwrapped_model.saved_state_dict[
+            "model.layers.2.feed_forward.experts.0.w1.weight"
+        ],
+        gate_up[0, :2],
+    )
+    assert torch.equal(
+        unwrapped_model.saved_state_dict[
+            "model.layers.2.feed_forward.experts.1.w2.weight"
+        ],
+        down[1],
+    )

--- a/tests/test_load_models.py
+++ b/tests/test_load_models.py
@@ -1,0 +1,104 @@
+import builtins
+import sys
+import types
+
+import pytest
+
+from leap_finetune.checkpointing import model_loading
+from leap_finetune.checkpointing.model_loading import (
+    _is_moe_model,
+    _maybe_enable_grouped_mm,
+    _resolve_chat_template,
+    _resolve_model_id,
+)
+
+pytestmark = pytest.mark.configs
+
+
+class DummyConfig:
+    def __init__(self, model_type: str, architectures: list[str]) -> None:
+        self.model_type = model_type
+        self.architectures = architectures
+
+
+class DummyModel:
+    def __init__(self, model_type: str, architectures: list[str]) -> None:
+        self.config = DummyConfig(model_type, architectures)
+        self.called = False
+        self.impl = None
+
+    def set_experts_implementation(self, impl: str) -> None:
+        self.called = True
+        self.impl = impl
+
+
+def test_sdpa_when_flash_attn_metadata_missing(monkeypatch):
+    monkeypatch.setattr(model_loading, "is_flash_attn_2_available", lambda: False)
+
+    assert model_loading._get_attn_implementation() == "sdpa"
+
+
+def test_sdpa_when_flash_attn_import_fails(monkeypatch):
+    monkeypatch.setattr(model_loading, "is_flash_attn_2_available", lambda: True)
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "flash_attn":
+            raise ImportError("broken extension")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert model_loading._get_attn_implementation() == "sdpa"
+
+
+def test_flash_attention_when_import_succeeds(monkeypatch):
+    monkeypatch.setattr(model_loading, "is_flash_attn_2_available", lambda: True)
+    flash_attn = types.ModuleType("flash_attn")
+    flash_attn.flash_attn_func = object()
+    flash_attn.flash_attn_varlen_func = object()
+    monkeypatch.setitem(sys.modules, "flash_attn", flash_attn)
+
+    assert model_loading._get_attn_implementation() == "flash_attention_2"
+
+
+def test_resolve_model_id_expands_liquidai_short_name():
+    assert _resolve_model_id("LFM2-24B-A2B") == "LiquidAI/LFM2-24B-A2B"
+
+
+def test_resolve_model_id_keeps_qualified_hf_id():
+    assert _resolve_model_id("LiquidAI/LFM2-24B-A2B") == "LiquidAI/LFM2-24B-A2B"
+
+
+def test_resolve_model_id_keeps_other_qualified_hf_id():
+    assert _resolve_model_id("some-org/some-model") == "some-org/some-model"
+
+
+def test_resolve_model_id_keeps_remote_uri():
+    assert _resolve_model_id("s3://bucket/model") == "s3://bucket/model"
+
+
+def test_resolve_model_id_keeps_existing_local_dir(tmp_path):
+    model_dir = tmp_path / "local-model"
+    model_dir.mkdir()
+
+    assert _resolve_model_id(str(model_dir)) == str(model_dir)
+
+
+def test_resolve_chat_template_explicit_override_wins():
+    assert _resolve_chat_template(chat_template="custom-template") == "custom-template"
+
+
+def test_grouped_mm_override_only_applies_to_moe_models():
+    dense = DummyModel("lfm2", ["Lfm2ForCausalLM"])
+    moe = DummyModel("lfm2_moe", ["Lfm2MoeForCausalLM"])
+
+    assert not _is_moe_model(dense)
+    assert _is_moe_model(moe)
+
+    _maybe_enable_grouped_mm(dense)
+    _maybe_enable_grouped_mm(moe)
+
+    assert dense.called is False
+    assert moe.called is True
+    assert moe.impl == "grouped_mm"

--- a/tests/test_moe_ep_runtime.py
+++ b/tests/test_moe_ep_runtime.py
@@ -1,0 +1,183 @@
+import torch
+import torch.nn as nn
+
+from leap_finetune.training.moe_utils import ep_runtime as moe_ep_module
+
+
+def test_sender_expert_layout_round_trip():
+    counts_by_sender = torch.tensor([[2, 1], [1, 2]], dtype=torch.long)
+    tokens = torch.arange(6, dtype=torch.float32).unsqueeze(-1)
+
+    expert_major = moe_ep_module.sender_major_to_expert_major(
+        tokens,
+        counts_by_sender,
+    )
+    restored = moe_ep_module.expert_major_to_sender_major(
+        expert_major,
+        counts_by_sender,
+    )
+
+    assert expert_major.squeeze(-1).tolist() == [0, 1, 3, 2, 4, 5]
+    assert torch.equal(restored, tokens)
+
+
+def test_compute_local_experts_uses_expert_major_grouped_mm_with_weights():
+    class DummyExperts(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.gate_up_proj = nn.Parameter(torch.zeros(2, 8, 4))
+            self.down_proj = nn.Parameter(torch.zeros(2, 4, 4))
+            self.act_fn = torch.nn.functional.silu
+
+    experts = DummyExperts()
+    with torch.no_grad():
+        eye = torch.eye(4)
+        experts.gate_up_proj[:, :4, :] = eye
+        experts.gate_up_proj[:, 4:, :] = eye
+        experts.down_proj[:] = eye
+
+    tokens = torch.randn(5, 4)
+    counts_by_expert = torch.tensor([3, 2], dtype=torch.long)
+    weights = torch.tensor([[1.0], [0.5], [2.0], [1.5], [0.25]])
+
+    def fake_grouped_mm(input_, weight, offs):
+        outputs = []
+        start = 0
+        for expert_idx, end_t in enumerate(offs.tolist()):
+            end = int(end_t)
+            outputs.append(input_[start:end] @ weight[expert_idx])
+            start = end
+        return torch.cat(outputs, dim=0)
+
+    original_grouped_mm = moe_ep_module.grouped_mm
+    moe_ep_module.grouped_mm = fake_grouped_mm
+    try:
+        output = moe_ep_module.compute_local_experts(
+            experts,
+            tokens,
+            counts_by_expert,
+            weights,
+        )
+    finally:
+        moe_ep_module.grouped_mm = original_grouped_mm
+
+    expected = torch.nn.functional.silu(tokens) * tokens * weights
+    assert torch.allclose(output, expected)
+
+
+def test_token_unpermutation_unsorts_before_single_reverse_a2a():
+    dispatcher = moe_ep_module.EPTokenDispatcher(
+        n_local_experts=2,
+        local_expert_indices=[0, 1],
+        n_experts=4,
+        top_k=1,
+        ep_size=2,
+        ep_group=object(),
+    )
+    dispatcher.input_splits = [3, 3]
+    dispatcher.output_splits = [3, 3]
+    dispatcher.tokens_per_local_expert_by_sender = torch.tensor(
+        [[2, 1], [1, 2]],
+        dtype=torch.long,
+    )
+    dispatcher._reverse_map = torch.arange(6, dtype=torch.long)
+    dispatcher._n_tokens = 6
+    dispatcher._hidden_size = 1
+    expert_output = torch.tensor([[0.0], [1.0], [3.0], [2.0], [4.0], [5.0]])
+
+    a2a_inputs = []
+    original_a2a = moe_ep_module.all_to_all_single_autograd
+
+    def fake_a2a(tensor, output_split_sizes, input_split_sizes, group):
+        a2a_inputs.append(tensor.clone())
+        return tensor
+
+    moe_ep_module.all_to_all_single_autograd = fake_a2a
+    try:
+        output = dispatcher.token_unpermutation(expert_output)
+    finally:
+        moe_ep_module.all_to_all_single_autograd = original_a2a
+
+    assert torch.equal(a2a_inputs[0].squeeze(-1), torch.arange(6, dtype=torch.float32))
+    assert torch.equal(output.squeeze(-1), torch.arange(6, dtype=torch.float32))
+
+
+def test_token_unpermutation_uses_single_reverse_a2a():
+    dispatcher = moe_ep_module.EPTokenDispatcher(
+        n_local_experts=1,
+        local_expert_indices=[0],
+        n_experts=1,
+        top_k=1,
+        ep_size=2,
+        ep_group=object(),
+    )
+    dispatcher.input_splits = [8, 0]
+    dispatcher.output_splits = [4, 4]
+    dispatcher._reverse_map = torch.arange(8, dtype=torch.long)
+    dispatcher._n_tokens = 8
+    dispatcher._hidden_size = 2
+
+    expert_output = torch.zeros(8, 2, dtype=torch.float32)
+    calls = []
+
+    def fake_a2a(tensor, output_split_sizes, input_split_sizes, group):
+        calls.append((list(output_split_sizes), list(input_split_sizes)))
+        return torch.zeros(sum(output_split_sizes), 2, dtype=torch.float32)
+
+    original_a2a = moe_ep_module.all_to_all_single_autograd
+    moe_ep_module.all_to_all_single_autograd = fake_a2a
+    try:
+        dispatcher.token_unpermutation(expert_output)
+    finally:
+        moe_ep_module.all_to_all_single_autograd = original_a2a
+
+    assert calls == [([8, 0], [4, 4])]
+
+
+def test_token_permutation_exchanges_weights_and_sorts_to_expert_major():
+    dispatcher = moe_ep_module.EPTokenDispatcher(
+        n_local_experts=2,
+        local_expert_indices=[0, 1],
+        n_experts=4,
+        top_k=1,
+        ep_size=2,
+        ep_group=object(),
+    )
+    dispatcher.input_splits = [3, 3]
+    dispatcher.output_splits = [3, 3]
+    dispatcher.tokens_per_local_expert_by_sender = torch.tensor(
+        [[2, 1], [1, 2]],
+        dtype=torch.long,
+    )
+
+    permuted = torch.arange(6, dtype=torch.float32).unsqueeze(-1)
+    weights = torch.arange(10, 16, dtype=torch.float32).unsqueeze(-1)
+    reverse_map = torch.arange(6, dtype=torch.long)
+    calls = []
+
+    def fake_permute_tokens(
+        hidden_states, selected_experts, routing_weights, n_experts
+    ):
+        return permuted, weights, reverse_map, torch.tensor([3, 3])
+
+    def fake_a2a(tensor, output_split_sizes, input_split_sizes, group):
+        calls.append((list(output_split_sizes), list(input_split_sizes)))
+        return tensor
+
+    original_permute = moe_ep_module.permute_tokens
+    original_a2a = moe_ep_module.all_to_all_single_autograd
+    moe_ep_module.permute_tokens = fake_permute_tokens
+    moe_ep_module.all_to_all_single_autograd = fake_a2a
+    try:
+        output, output_weights = dispatcher.token_permutation(
+            torch.zeros(6, 1),
+            torch.zeros(6, 1, dtype=torch.long),
+            torch.ones(6, 1),
+        )
+    finally:
+        moe_ep_module.permute_tokens = original_permute
+        moe_ep_module.all_to_all_single_autograd = original_a2a
+
+    assert calls == [([3, 3], [3, 3]), ([3, 3], [3, 3])]
+    assert output.squeeze(-1).tolist() == [0, 1, 3, 2, 4, 5]
+    assert output_weights.squeeze(-1).tolist() == [10, 11, 13, 12, 14, 15]

--- a/tests/test_moe_losses.py
+++ b/tests/test_moe_losses.py
@@ -1,0 +1,91 @@
+import torch
+import torch.nn as nn
+
+from leap_finetune.training.moe_utils.losses import (
+    MoETrainingConfig,
+    apply_moe_losses,
+    switch_load_balancing_loss,
+)
+
+
+class Lfm2MoeSparseMoeBlock(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.gate = nn.Linear(4, 2, bias=False)
+        self.top_k = 1
+        self.score_function = "sigmoid"
+        self.norm_topk_prob = False
+        self.experts = nn.ModuleList([nn.Linear(4, 4, bias=False) for _ in range(2)])
+
+
+class DummyContainer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.block = Lfm2MoeSparseMoeBlock()
+
+
+class TrackingExperts(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.called = False
+        self.last_hidden_shape = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        selected_experts: torch.Tensor,
+        routing_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        self.called = True
+        self.last_hidden_shape = tuple(hidden_states.shape)
+        return hidden_states + routing_weights.sum(dim=-1, keepdim=True).to(
+            hidden_states.dtype
+        )
+
+
+def test_switch_load_balancing_loss_matches_formula():
+    router_probs = torch.tensor([[0.8, 0.2], [0.1, 0.9]])
+    selected_experts = torch.tensor([[0], [1]])
+
+    loss = switch_load_balancing_loss(
+        router_probs=router_probs,
+        selected_experts=selected_experts,
+        num_experts=2,
+        top_k=1,
+        coeff=0.5,
+    )
+
+    aggregated_probs = router_probs.mean(dim=0)
+    tokens_per_expert = torch.tensor([1.0, 1.0])
+    expected = (aggregated_probs * tokens_per_expert).sum() * 2 * 0.5 / 2
+    assert torch.allclose(loss, expected)
+
+
+def test_apply_moe_losses_handles_blocks_without_num_experts_attr():
+    torch.manual_seed(0)
+    model = DummyContainer()
+
+    apply_moe_losses(model, MoETrainingConfig(aux_loss_coef=0.01, z_loss_coef=0.001))
+
+    hidden_states = torch.randn(2, 3, 4)
+    output = model.block(hidden_states)
+
+    assert output.shape == hidden_states.shape
+    assert hasattr(model.block, "_moe_aux_loss")
+    assert hasattr(model.block, "_moe_z_loss")
+    assert model.block._moe_num_experts == 2
+
+
+def test_apply_moe_losses_delegates_non_ep_expert_compute_to_model_experts():
+    torch.manual_seed(0)
+    model = DummyContainer()
+    model.block.experts = TrackingExperts()
+
+    apply_moe_losses(model, MoETrainingConfig(aux_loss_coef=0.01, z_loss_coef=0.001))
+
+    hidden_states = torch.randn(2, 3, 4)
+    output = model.block(hidden_states)
+
+    assert output.shape == hidden_states.shape
+    assert model.block.experts.called is True
+    assert model.block.experts.last_hidden_shape == (6, 4)

--- a/tests/test_moe_trainers.py
+++ b/tests/test_moe_trainers.py
@@ -1,0 +1,34 @@
+from torch.utils.data import Dataset
+
+from leap_finetune.training.moe_sft import LFMMoeSFTTrainer
+
+
+class LengthDataset(Dataset):
+    column_names = ["length"]
+
+    def __init__(self, lengths: list[int]) -> None:
+        self.lengths = lengths
+
+    def __len__(self) -> int:
+        return len(self.lengths)
+
+    def __getitem__(self, item):
+        if isinstance(item, str):
+            if item != "length":
+                raise KeyError(item)
+            return self.lengths
+        return {"length": self.lengths[item]}
+
+
+def test_moe_sft_length_grouping_uses_dp_seed_for_ep():
+    trainer = LFMMoeSFTTrainer.__new__(LFMMoeSFTTrainer)
+    trainer.train_dataset = LengthDataset([8, 3, 5, 2])
+    trainer._train_batch_size = 2
+    trainer.data_collator = lambda features: features
+    trainer.ep_config = {"dp_rank": 3}
+
+    dataloader = trainer.get_train_dataloader()
+
+    assert dataloader.sampler is not None
+    assert dataloader.sampler.generator is not None
+    assert dataloader.sampler.generator.initial_seed() == 45

--- a/tests/test_rank_groups.py
+++ b/tests/test_rank_groups.py
@@ -1,0 +1,88 @@
+import pytest
+
+from leap_finetune.distribution.data_sharding import ExpertParallelDataConfig
+from leap_finetune.distribution.rank_groups import build_replica_group_blocks
+
+
+def test_build_replica_group_blocks_chunks_workers_per_node():
+    blocks = build_replica_group_blocks(
+        world_size=8,
+        replica_group_size=2,
+        worker_node_ids=["node-a"] * 4 + ["node-b"] * 4,
+    )
+
+    assert blocks == [
+        ("node-a", [0, 1], 0),
+        ("node-a", [2, 3], 1),
+        ("node-b", [4, 5], 0),
+        ("node-b", [6, 7], 1),
+    ]
+
+
+def test_build_replica_group_blocks_handles_interleaved_nodes():
+    blocks = build_replica_group_blocks(
+        world_size=4,
+        replica_group_size=2,
+        worker_node_ids=["node-a", "node-b", "node-a", "node-b"],
+    )
+
+    assert blocks == [
+        ("node-a", [0, 2], 0),
+        ("node-b", [1, 3], 0),
+    ]
+
+
+def test_rank_contiguous_replica_groups_reject_interleaved_nodes():
+    with pytest.raises(ValueError, match="rank-contiguous EP process groups"):
+        build_replica_group_blocks(
+            world_size=4,
+            replica_group_size=2,
+            worker_node_ids=["node-a", "node-b", "node-a", "node-b"],
+            require_rank_contiguous=True,
+        )
+
+
+def test_expert_parallel_data_config_requires_ep_group_alignment():
+    config = ExpertParallelDataConfig(expert_parallel_size=2)
+
+    with pytest.raises(ValueError, match="rank-contiguous EP process groups"):
+        config.configure(
+            datasets={},
+            world_size=4,
+            worker_handles=None,
+            worker_node_ids=["node-a", "node-b", "node-a", "node-b"],
+        )
+
+
+def test_replica_groups_share_the_same_dp_shard_assignment():
+    blocks = build_replica_group_blocks(
+        world_size=8,
+        replica_group_size=2,
+        worker_node_ids=["node-a"] * 4 + ["node-b"] * 4,
+    )
+    rank_to_shard_index = {
+        rank: shard_index
+        for shard_index, (_, ranks, _) in enumerate(blocks)
+        for rank in ranks
+    }
+
+    assert rank_to_shard_index[0] == rank_to_shard_index[1]
+    assert rank_to_shard_index[2] == rank_to_shard_index[3]
+    assert rank_to_shard_index[4] == rank_to_shard_index[5]
+    assert rank_to_shard_index[6] == rank_to_shard_index[7]
+
+    assert rank_to_shard_index[0] != rank_to_shard_index[2]
+    assert rank_to_shard_index[2] != rank_to_shard_index[4]
+    assert rank_to_shard_index[4] != rank_to_shard_index[6]
+
+
+def test_build_replica_group_blocks_requires_full_groups_per_node():
+    with pytest.raises(
+        ValueError,
+        match="node node-a has 3 ranks, which is not divisible by group_size \\(2\\)",
+    ):
+        build_replica_group_blocks(
+            world_size=4,
+            replica_group_size=2,
+            worker_node_ids=["node-a", "node-a", "node-a", "node-b"],
+        )

--- a/tests/test_ray_cluster_support.py
+++ b/tests/test_ray_cluster_support.py
@@ -1,0 +1,94 @@
+from leap_finetune.distribution.ray_runtime import (
+    get_requested_ray_address,
+    resolve_num_workers,
+)
+from leap_finetune.distribution.backends.slurm import generate_slurm_script
+
+
+def test_get_requested_ray_address_prefers_leap_env(monkeypatch):
+    monkeypatch.setenv("RAY_ADDRESS", "ray-a:6379")
+    monkeypatch.setenv("LEAP_RAY_ADDRESS", "ray-b:6379")
+    assert get_requested_ray_address({"address": "ray-c:6379"}) == "ray-b:6379"
+
+
+def test_get_requested_ray_address_uses_config(monkeypatch):
+    monkeypatch.delenv("RAY_ADDRESS", raising=False)
+    monkeypatch.delenv("LEAP_RAY_ADDRESS", raising=False)
+    assert get_requested_ray_address({"address": "ray-c:6379"}) == "ray-c:6379"
+
+
+def test_resolve_num_workers_prefers_env(monkeypatch):
+    monkeypatch.setenv("LEAP_RAY_NUM_WORKERS", "16")
+    assert (
+        resolve_num_workers(
+            None,
+            local_num_gpus=8,
+            connected_to_existing_cluster=False,
+        )
+        == 16
+    )
+
+
+def test_resolve_num_workers_uses_ray_config(monkeypatch):
+    monkeypatch.delenv("LEAP_RAY_NUM_WORKERS", raising=False)
+    monkeypatch.delenv("LEAP_NUM_WORKERS", raising=False)
+    assert (
+        resolve_num_workers(
+            {"num_workers": 12},
+            local_num_gpus=8,
+            connected_to_existing_cluster=False,
+        )
+        == 12
+    )
+
+
+def test_resolve_num_workers_uses_local_gpu_count(monkeypatch):
+    monkeypatch.delenv("LEAP_RAY_NUM_WORKERS", raising=False)
+    monkeypatch.delenv("LEAP_NUM_WORKERS", raising=False)
+    assert (
+        resolve_num_workers(
+            None,
+            local_num_gpus=8,
+            connected_to_existing_cluster=False,
+        )
+        == 8
+    )
+
+
+def test_multinode_slurm_script_starts_ray_cluster(tmp_path):
+    config_path = tmp_path / "example.yaml"
+    config_path.write_text(
+        """
+project_name: test_multinode
+model_name: LFM2-1.2B
+training_type: sft
+dataset:
+  path: HuggingFaceTB/smoltalk
+  type: sft
+training_config:
+  extends: DEFAULT_SFT
+peft_config:
+  use_peft: false
+slurm:
+  nodes: 2
+  ntasks_per_node: 1
+  gpus_per_task: 8
+"""
+    )
+
+    script_path = generate_slurm_script(
+        config_path,
+        {
+            "project_name": "test_multinode",
+            "slurm": {
+                "nodes": 2,
+                "ntasks_per_node": 1,
+                "gpus_per_task": 8,
+            },
+        },
+        tmp_path,
+    )
+    script = script_path.read_text()
+    assert "src/leap_finetune/distribution/backends/slurm_ray.sh" in script
+    assert "export RAY_ADDRESS" in script
+    assert "ray_slurm_start_cluster_bg" in script

--- a/tests/test_ray_data_utils.py
+++ b/tests/test_ray_data_utils.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pyarrow as pa
+
 from leap_finetune.data_loading import ray_data_utils
 from leap_finetune.data_loading.dataset_loader import DatasetLoader
 from leap_finetune.data_loading.ray_data_utils import (
@@ -14,8 +16,9 @@ class _RowShard:
     def __init__(self, rows):
         self._rows = rows
 
-    def iter_rows(self):
-        yield from self._rows
+    def iter_batches(self, batch_format):
+        assert batch_format == "pyarrow"
+        yield pa.Table.from_pylist(self._rows)
 
 
 def test_ray_dataset_to_hf_materializes_rows():

--- a/tests/test_ray_data_utils.py
+++ b/tests/test_ray_data_utils.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+from leap_finetune.data_loading import ray_data_utils
+from leap_finetune.data_loading.dataset_loader import DatasetLoader
+from leap_finetune.data_loading.ray_data_utils import (
+    _build_tokenization_cache_key,
+    _load_tokenization_cache,
+    _save_tokenization_cache,
+    ray_dataset_to_hf,
+)
+
+
+class _RowShard:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def iter_rows(self):
+        yield from self._rows
+
+
+def test_ray_dataset_to_hf_materializes_rows():
+    shard = _RowShard(
+        [
+            {"input_ids": [1, 2], "length": 2},
+            {"input_ids": [3], "length": 1},
+        ]
+    )
+
+    ds = ray_dataset_to_hf(shard)
+
+    assert len(ds) == 2
+    assert ds[0]["input_ids"] == [1, 2]
+    assert ds[1]["input_ids"] == [3]
+
+
+class _FakeRayDataset:
+    def __init__(self, name):
+        self.name = name
+
+    def write_parquet(self, path):
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+        (path / f"{self.name}.parquet").write_text(self.name)
+
+
+def test_cache_write_is_atomic_and_requires_success_marker(monkeypatch, tmp_path):
+    cache_root = tmp_path / "tokenized"
+    monkeypatch.setattr(ray_data_utils, "TOKENIZATION_CACHE_DIR", cache_root)
+
+    loaded = []
+
+    def fake_read_parquet(path):
+        loaded.append(Path(path).name)
+        return path
+
+    monkeypatch.setattr(ray_data_utils.ray.data, "read_parquet", fake_read_parquet)
+
+    fingerprint = "abc123"
+    train = _FakeRayDataset("train")
+    eval_ds = _FakeRayDataset("eval")
+    key = {"dataset_path": "/data/train", "has_eval": True}
+
+    assert _load_tokenization_cache(fingerprint) is None
+
+    _save_tokenization_cache(fingerprint, train, eval_ds, key)
+
+    cache_dir = cache_root / fingerprint
+    assert (cache_dir / "_SUCCESS").exists()
+    assert (cache_dir / "fingerprint.json").exists()
+    assert not list(cache_root.glob(f"{fingerprint}.tmp-*"))
+
+    cached = _load_tokenization_cache(fingerprint)
+    assert cached == (str(cache_dir / "train"), str(cache_dir / "eval"))
+    assert loaded == ["train", "eval"]
+
+
+def test_sft_cache_key_includes_template_hash_and_overlength_policy(tmp_path):
+    template = tmp_path / "chat_template.jinja"
+    template.write_text("template v1")
+    loader = DatasetLoader(
+        dataset_path="/data/train",
+        dataset_type="sft",
+        val_dataset_path="/data/eval",
+        test_size=None,
+    )
+
+    fingerprint_v1, key_v1 = _build_tokenization_cache_key(
+        loader,
+        shuffle_seed=42,
+        tokenizer_id="model",
+        training_config={
+            "max_length": 120000,
+            "drop_overlength": True,
+            "chat_template_path": str(template),
+        },
+    )
+
+    template.write_text("template v2")
+    fingerprint_v2, key_v2 = _build_tokenization_cache_key(
+        loader,
+        shuffle_seed=42,
+        tokenizer_id="model",
+        training_config={
+            "max_length": 120000,
+            "drop_overlength": True,
+            "chat_template_path": str(template),
+        },
+    )
+
+    assert key_v1["drop_overlength"] is True
+    assert key_v1["chat_template_path_sha256"] != key_v2["chat_template_path_sha256"]
+    assert fingerprint_v1 != fingerprint_v2

--- a/tests/test_sft_loss_masks.py
+++ b/tests/test_sft_loss_masks.py
@@ -19,8 +19,9 @@ class _FakeTokenizer:
         max_length=None,
         return_dict=False,
         return_assistant_tokens_mask=False,
+        tools=None,
     ):
-        del messages, tokenize, truncation, max_length
+        del messages, tokenize, truncation, max_length, tools
         output = {"input_ids": [10, 11, 12, 13, 14, 15]}
         if return_assistant_tokens_mask:
             output["assistant_masks"] = [0, 1, 1, 0, 1, 1]
@@ -150,8 +151,9 @@ class _PackingTokenizer(_FakeTokenizer):
         max_length=None,
         return_dict=False,
         return_assistant_tokens_mask=False,
+        tools=None,
     ):
-        del tokenize, truncation, max_length
+        del tokenize, truncation, max_length, tools
         key = messages[0]["content"]
         if key == "one":
             output = {"input_ids": [1, 2, 3]}
@@ -226,8 +228,9 @@ class _VariableLengthTokenizer(_FakeTokenizer):
         max_length=None,
         return_dict=False,
         return_assistant_tokens_mask=False,
+        tools=None,
     ):
-        del tokenize
+        del tokenize, tools
         length = int(messages[0]["content"])
         input_ids = list(range(length))
         if truncation and max_length is not None:

--- a/tests/test_sft_loss_masks.py
+++ b/tests/test_sft_loss_masks.py
@@ -1,0 +1,262 @@
+import torch
+from leap_finetune.data_loading.tokenize_data import (
+    _final_assistant_span_mask,
+    tokenize_and_pack_sft,
+    tokenize_sft,
+)
+from leap_finetune.training.sft import build_sft_data_collator
+
+
+class _FakeTokenizer:
+    pad_token_id = 0
+    eos_token_id = 99
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=True,
+        truncation=True,
+        max_length=None,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+    ):
+        del messages, tokenize, truncation, max_length
+        output = {"input_ids": [10, 11, 12, 13, 14, 15]}
+        if return_assistant_tokens_mask:
+            output["assistant_masks"] = [0, 1, 1, 0, 1, 1]
+        return output if return_dict else output["input_ids"]
+
+    def __call__(self, text, truncation=True, max_length=None):
+        del truncation, max_length
+        return {"input_ids": [1, 2, 3] if text else []}
+
+
+def test_final_assistant_span_mask_keeps_only_last_assistant_segment():
+    mask = [0, 1, 1, 0, 1, 1, 1, 0]
+    assert _final_assistant_span_mask(mask) == [0, 0, 0, 0, 1, 1, 1, 0]
+
+
+def test_tokenize_sft_emits_assistant_masks():
+    tokenizer = _FakeTokenizer()
+    row = {"messages": [{"role": "user", "content": "x"}]}
+
+    tokenized = tokenize_sft(
+        row,
+        tokenizer,
+        max_length=128,
+        assistant_only_loss=True,
+    )
+
+    assert tokenized["input_ids"] == [10, 11, 12, 13, 14, 15]
+    assert tokenized["assistant_masks"] == [0, 1, 1, 0, 1, 1]
+
+
+def test_tokenize_sft_emits_completion_mask_for_final_assistant_span():
+    tokenizer = _FakeTokenizer()
+    row = {"messages": [{"role": "user", "content": "x"}]}
+
+    tokenized = tokenize_sft(
+        row,
+        tokenizer,
+        max_length=128,
+        completion_only_loss=True,
+    )
+
+    assert tokenized["completion_mask"] == [0, 0, 0, 0, 1, 1]
+
+
+def test_tokenize_sft_rejects_text_rows_for_masked_loss():
+    tokenizer = _FakeTokenizer()
+    row = {"text": "plain text"}
+
+    try:
+        tokenize_sft(
+            row,
+            tokenizer,
+            max_length=128,
+            assistant_only_loss=True,
+        )
+    except ValueError as exc:
+        assert "require conversational SFT rows" in str(exc)
+    else:
+        raise AssertionError("Expected tokenize_sft to reject text rows")
+
+
+def test_collator_applies_intersection_of_completion_and_assistant_masks():
+    tokenizer = _FakeTokenizer()
+    collator = build_sft_data_collator(
+        tokenizer,
+        {
+            "assistant_only_loss": True,
+            "completion_only_loss": True,
+            "padding_free": False,
+        },
+    )
+
+    batch = collator(
+        [
+            {
+                "input_ids": [10, 11, 12, 13, 14, 15],
+                "assistant_masks": [0, 1, 1, 0, 1, 1],
+                "completion_mask": [0, 0, 0, 0, 1, 1],
+            }
+        ]
+    )
+
+    assert torch.equal(
+        batch["labels"],
+        torch.tensor([[-100, -100, -100, -100, 14, 15]]),
+    )
+
+
+def test_collator_applies_masks_in_padding_free_mode():
+    tokenizer = _FakeTokenizer()
+    collator = build_sft_data_collator(
+        tokenizer,
+        {
+            "assistant_only_loss": True,
+            "completion_only_loss": True,
+            "padding_free": True,
+        },
+    )
+
+    batch = collator(
+        [
+            {
+                "input_ids": [10, 11, 12, 13],
+                "assistant_masks": [0, 1, 1, 0],
+                "completion_mask": [0, 1, 1, 0],
+            },
+            {
+                "input_ids": [20, 21],
+                "assistant_masks": [1, 1],
+                "completion_mask": [0, 1],
+            },
+        ]
+    )
+
+    assert torch.equal(
+        batch["labels"],
+        torch.tensor([[-100, 11, 12, -100, -100, 21]]),
+    )
+
+
+class _PackingTokenizer(_FakeTokenizer):
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=True,
+        truncation=True,
+        max_length=None,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+    ):
+        del tokenize, truncation, max_length
+        key = messages[0]["content"]
+        if key == "one":
+            output = {"input_ids": [1, 2, 3]}
+            if return_assistant_tokens_mask:
+                output["assistant_masks"] = [0, 1, 1]
+        elif key == "two":
+            output = {"input_ids": [4, 5]}
+            if return_assistant_tokens_mask:
+                output["assistant_masks"] = [0, 1]
+        else:
+            raise AssertionError(f"Unexpected key: {key}")
+        return output if return_dict else output["input_ids"]
+
+
+class _FakeRayDataset:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def map(self, fn, fn_kwargs=None):
+        fn_kwargs = fn_kwargs or {}
+        return _FakeRayDataset([fn(row, **fn_kwargs) for row in self._rows])
+
+    def filter(self, fn):
+        return _FakeRayDataset([row for row in self._rows if fn(row)])
+
+    def iter_rows(self):
+        yield from self._rows
+
+
+class _FakePackedDataset:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def iter_rows(self):
+        yield from self._rows
+
+
+def test_tokenize_and_pack_sft_preserves_assistant_masks(monkeypatch):
+    tokenizer = _PackingTokenizer()
+    ds = _FakeRayDataset(
+        [
+            {"messages": [{"role": "user", "content": "one"}]},
+            {"messages": [{"role": "user", "content": "two"}]},
+        ]
+    )
+
+    monkeypatch.setattr(
+        "leap_finetune.data_loading.tokenize_data.ray.data.from_arrow",
+        lambda table: _FakePackedDataset(table.to_pylist()),
+    )
+
+    packed = tokenize_and_pack_sft(
+        ds,
+        tokenizer,
+        max_length=8,
+        packing=True,
+        assistant_only_loss=True,
+    )
+
+    rows = list(packed.iter_rows())
+    assert len(rows) == 1
+    assert rows[0]["input_ids"] == [1, 2, 3, 4, 5]
+    assert rows[0]["assistant_masks"] == [0, 1, 1, 0, 1]
+
+
+class _VariableLengthTokenizer(_FakeTokenizer):
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=True,
+        truncation=True,
+        max_length=None,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+    ):
+        del tokenize
+        length = int(messages[0]["content"])
+        input_ids = list(range(length))
+        if truncation and max_length is not None:
+            input_ids = input_ids[:max_length]
+        output = {"input_ids": input_ids}
+        if return_assistant_tokens_mask:
+            output["assistant_masks"] = [1] * len(input_ids)
+        return output if return_dict else output["input_ids"]
+
+
+def test_tokenize_and_pack_sft_can_drop_overlength_without_truncating():
+    tokenizer = _VariableLengthTokenizer()
+    ds = _FakeRayDataset(
+        [
+            {"messages": [{"role": "user", "content": "3"}]},
+            {"messages": [{"role": "user", "content": "6"}]},
+        ]
+    )
+
+    filtered = tokenize_and_pack_sft(
+        ds,
+        tokenizer,
+        max_length=4,
+        packing=False,
+        assistant_only_loss=True,
+        drop_overlength=True,
+    )
+
+    rows = list(filtered.iter_rows())
+    assert len(rows) == 1
+    assert rows[0]["input_ids"] == [0, 1, 2]
+    assert rows[0]["assistant_masks"] == [1, 1, 1]

--- a/tests/test_tool_call_templates.py
+++ b/tests/test_tool_call_templates.py
@@ -1,0 +1,265 @@
+import json
+
+import pytest
+
+from trl.data_utils import maybe_apply_chat_template
+
+pytestmark = pytest.mark.data
+
+SAMPLE_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"},
+                    "unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                    },
+                },
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+
+class TestLFMToolCallTemplate:
+    """Empirically document what apply_chat_template auto-formats for LFM tokenizers.
+
+    Key findings from reading the LFM2-1.2B chat template:
+
+    1. The template ONLY reads message["content"] — it completely ignores
+       message["tool_calls"]. Structured tool_calls are NOT supported.
+    2. tools= parameter → <|tool_list_start|>[...]<|tool_list_end|> in system msg
+    3. role="tool" → wraps content with <|tool_response_start|>/<|tool_response_end|>
+    4. Content is passed through VERBATIM — no reordering, no marker injection
+
+    This means tool call data MUST be pre-formatted in the content field:
+    - Tool calls must use <|tool_call_start|>...<|tool_call_end|> in content
+    - Tool calls must appear BEFORE any text in content
+    - Foreign markers (Qwen <tool_call>, Mistral [TOOL_CALLS]) will pass through
+      as plain text and NOT be converted to LFM format
+    """
+
+    @pytest.fixture(scope="class")
+    def tokenizer(self):
+        from leap_finetune.checkpointing.model_loading import load_tokenizer
+
+        return load_tokenizer("LFM2-1.2B")
+
+    # === 1. Template ignores structured tool_calls ===
+
+    def test_structured_tool_calls_crashes_without_content(self, tokenizer):
+        """Structured tool_calls without content field crashes the template.
+        The template tries to access message["content"] which is Undefined.
+        """
+        messages = [
+            {"role": "user", "content": "What's the weather in SF?"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": json.dumps({"location": "SF"}),
+                        },
+                    }
+                ],
+            },
+        ]
+        with pytest.raises(TypeError, match="Undefined"):
+            tokenizer.apply_chat_template(messages, tools=SAMPLE_TOOLS, tokenize=False)
+
+    def test_structured_tool_calls_ignored_when_content_present(self, tokenizer):
+        """When both content and tool_calls are present, tool_calls is ignored.
+        Only the content text appears in the output.
+        """
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "Let me check that for you.",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": json.dumps({"location": "SF"}),
+                        },
+                    }
+                ],
+            },
+        ]
+        output = tokenizer.apply_chat_template(
+            messages, tools=SAMPLE_TOOLS, tokenize=False
+        )
+        # tool_calls field is completely ignored — no tool call markers generated
+        assert "<|tool_call_start|>" not in output
+        # Only content text appears in the assistant turn
+        assert "Let me check that for you." in output
+
+    # === 2. Pre-formatted LFM markers in content ===
+
+    def test_preformatted_lfm_markers_pass_through(self, tokenizer):
+        """Content with LFM tool call markers passes through verbatim."""
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": '<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>',
+            },
+        ]
+        output = tokenizer.apply_chat_template(messages, tokenize=False)
+        count = output.count("<|tool_call_start|>")
+        assert count == 1, (
+            f"Expected 1 occurrence of <|tool_call_start|>, found {count} in:\n{output}"
+        )
+
+    def test_preformatted_tool_call_then_text(self, tokenizer):
+        """Correct ordering: tool call first, then text. Passes through as-is."""
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": '<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>\nChecking now.',
+            },
+        ]
+        output = tokenizer.apply_chat_template(messages, tokenize=False)
+        tool_pos = output.find("<|tool_call_start|>")
+        text_pos = output.find("Checking now.")
+        assert tool_pos < text_pos
+
+    def test_preformatted_wrong_order_passes_through(self, tokenizer):
+        """Wrong ordering (text first) also passes through — template does NOT fix it.
+        This is the bug that validation needs to catch.
+        """
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": 'Checking now.\n<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>',
+            },
+        ]
+        output = tokenizer.apply_chat_template(messages, tokenize=False)
+        tool_pos = output.find("<|tool_call_start|>")
+        text_pos = output.find("Checking now.")
+        assert text_pos < tool_pos, (
+            "Expected wrong order to pass through, but template reordered it"
+        )
+
+    # === 3. Foreign markers ===
+
+    def test_qwen_markers_pass_through_unchanged(self, tokenizer):
+        """Qwen-style <tool_call> markers pass through as plain text.
+        The template does NOT convert them to LFM format.
+        """
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": '<tool_call>\n{"name": "get_weather"}\n</tool_call>',
+            },
+        ]
+        output = tokenizer.apply_chat_template(messages, tokenize=False)
+        assert "<tool_call>" in output
+        assert "</tool_call>" in output
+        assert "<|tool_call_start|>" not in output
+
+    # === 4. tools= parameter ===
+
+    def test_tools_parameter_produces_tool_list_markers(self, tokenizer):
+        """tools= kwarg adds tool definitions to system message."""
+        messages = [{"role": "user", "content": "What's the weather?"}]
+        output = tokenizer.apply_chat_template(
+            messages, tools=SAMPLE_TOOLS, tokenize=False
+        )
+        assert "<|tool_list_start|>" in output
+        assert "<|tool_list_end|>" in output
+        assert "get_weather" in output
+
+    # === 5. role="tool" ===
+
+    def test_tool_role_produces_response_markers(self, tokenizer):
+        """role='tool' wraps content with tool response special tokens."""
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": '<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>',
+            },
+            {"role": "tool", "content": '{"temp": 18, "unit": "celsius"}'},
+        ]
+        output = tokenizer.apply_chat_template(messages, tokenize=False)
+        assert "<|tool_response_start|>" in output
+        assert "<|tool_response_end|>" in output
+
+    def test_tool_role_without_tool_call_in_prior_message(self, tokenizer):
+        """role='tool' works even without a prior tool call (template doesn't validate)."""
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "tool", "content": '{"result": "ok"}'},
+        ]
+        output = tokenizer.apply_chat_template(messages, tokenize=False)
+        assert "<|tool_response_start|>" in output
+        assert "<|tool_response_end|>" in output
+
+    # === 6. DPO path via TRL ===
+
+    def test_trl_string_data_passes_through(self, tokenizer):
+        """TRL with pre-stringified DPO data passes strings through unchanged."""
+        row = {
+            "prompt": "What's the weather?",
+            "chosen": '<|tool_call_start|>[get_weather(location="SF")]<|tool_call_end|>',
+            "rejected": "I don't know the weather.",
+        }
+        result = maybe_apply_chat_template(row, tokenizer)
+        assert result["chosen"] == row["chosen"]
+        assert result["rejected"] == row["rejected"]
+
+    def test_trl_structured_tool_calls_not_converted(self, tokenizer):
+        """TRL fails to convert structured tool_calls — either crashes or
+        silently returns data unchanged (behavior depends on TRL internals).
+        Either way, the data is NOT properly converted to strings with LFM markers.
+        This confirms DPO tool call data must be pre-formatted in content.
+        """
+        row = {
+            "prompt": [{"role": "user", "content": "What's the weather?"}],
+            "chosen": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": json.dumps({"location": "SF"}),
+                            },
+                        }
+                    ],
+                }
+            ],
+            "rejected": [
+                {
+                    "role": "assistant",
+                    "content": "I don't have access to weather data.",
+                }
+            ],
+        }
+        try:
+            result = maybe_apply_chat_template(row, tokenizer)
+        except (TypeError, Exception):
+            # Template crash — structured tool_calls unsupported
+            return
+
+        # If it didn't crash, data should be unchanged (not converted to strings)
+        # Either way, <|tool_call_start|> won't appear in the chosen output
+        if isinstance(result["chosen"], str):
+            assert "<|tool_call_start|>" not in result["chosen"], (
+                "Structured tool_calls should not produce LFM markers via TRL"
+            )

--- a/tests/test_tool_call_validation.py
+++ b/tests/test_tool_call_validation.py
@@ -1,0 +1,497 @@
+from leap_finetune.data_loading.validate_tool_format import (
+    ToolFormatInfo,
+    detect_tool_format,
+    normalize_tool_format,
+    validate_tool_format,
+    tool_calls_to_pythonic,
+)
+from leap_finetune.checkpointing.model_info import get_model_family
+
+
+# === Model family detection ===
+
+
+class TestGetModelFamily:
+    def test_lfm2_models(self):
+        assert get_model_family("LFM2-1.2B") == "lfm2"
+        assert get_model_family("LFM2-2.6B") == "lfm2"
+        assert get_model_family("LFM2-8B-A1B") == "lfm2"
+        assert get_model_family("LFM2-350M") == "lfm2"
+
+    def test_lfm25_models(self):
+        assert get_model_family("LFM2.5-1.2B-Instruct") == "lfm25"
+        assert get_model_family("LFM2.5-8B-A1B-Instruct") == "lfm25"
+
+    def test_24b_exception(self):
+        assert get_model_family("LFM2-24B-A2B") == "lfm25"
+
+    def test_full_path(self):
+        assert get_model_family("LiquidAI/LFM2-1.2B") == "lfm2"
+        assert get_model_family("LiquidAI/LFM2.5-1.2B-Instruct") == "lfm25"
+
+
+# === Format detection ===
+
+
+class TestDetectToolFormat:
+    def test_lfm2_format(self):
+        samples = [
+            {
+                "conversations": [
+                    {
+                        "role": "system",
+                        "content": '<|tool_list_start|>[{"name": "f"}]<|tool_list_end|>',
+                    },
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": "<|tool_call_start|>[f()]<|tool_call_end|>",
+                    },
+                    {"role": "tool", "content": '{"result": 1}'},
+                ]
+            }
+        ]
+        info = detect_tool_format(samples)
+        assert info.detected_format == "lfm2"
+        assert info.has_tool_call_markers
+        assert info.has_tool_list_markers
+        assert info.has_tool_role
+
+    def test_lfm25_format(self):
+        samples = [
+            {
+                "conversations": [
+                    {"role": "system", "content": 'List of tools: [{"name": "f"}]'},
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": "<|tool_call_start|>[f()]<|tool_call_end|>",
+                    },
+                    {"role": "tool", "content": '{"result": 1}'},
+                ]
+            }
+        ]
+        info = detect_tool_format(samples)
+        assert info.detected_format == "lfm25"
+        assert info.has_tool_call_markers
+        assert not info.has_tool_list_markers
+
+    def test_structured_format(self):
+        samples = [
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "function": {"name": "f", "arguments": {}},
+                            }
+                        ],
+                    },
+                ]
+            }
+        ]
+        info = detect_tool_format(samples)
+        assert info.detected_format == "structured"
+        assert info.has_structured_tool_calls
+
+    def test_foreign_format(self):
+        samples = [
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": "<tool_call>get_weather</tool_call>",
+                    },
+                ]
+            }
+        ]
+        info = detect_tool_format(samples)
+        assert info.detected_format == "foreign"
+        assert info.has_foreign_markers
+        assert "<tool_call>" in info.foreign_markers_found
+
+    def test_no_tools(self):
+        samples = [
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi there"},
+                ]
+            }
+        ]
+        info = detect_tool_format(samples)
+        assert info.detected_format == "none"
+        assert not info.has_tool_calls
+
+    def test_prebaked_tool_response(self):
+        samples = [
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": "<|tool_call_start|>[f()]<|tool_call_end|>",
+                    },
+                    {
+                        "role": "tool",
+                        "content": '<|tool_response_start|>{"r": 1}<|tool_response_end|>',
+                    },
+                ]
+            }
+        ]
+        info = detect_tool_format(samples)
+        assert info.has_tool_response_markers
+
+
+# === Validation ===
+
+
+class TestValidateToolFormat:
+    def test_matched_lfm2(self):
+        info = ToolFormatInfo(
+            has_tool_calls=True,
+            has_tool_call_markers=True,
+            has_tool_list_markers=True,
+            detected_format="lfm2",
+        )
+        issues = validate_tool_format(info, "lfm2")
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) == 0
+
+    def test_matched_lfm25(self):
+        info = ToolFormatInfo(
+            has_tool_calls=True,
+            has_tool_call_markers=True,
+            detected_format="lfm25",
+        )
+        issues = validate_tool_format(info, "lfm25")
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) == 0
+
+    def test_lfm2_on_lfm25_warns(self):
+        info = ToolFormatInfo(
+            has_tool_calls=True,
+            has_tool_call_markers=True,
+            has_tool_list_markers=True,
+            detected_format="lfm2",
+        )
+        issues = validate_tool_format(info, "lfm25")
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert any(i.code == "TOOL_LIST_MARKERS_ON_LFM25" for i in warnings)
+        assert all(i.auto_fixable for i in warnings)
+
+    def test_lfm25_on_lfm2_warns(self):
+        info = ToolFormatInfo(
+            has_tool_calls=True,
+            has_tool_call_markers=True,
+            detected_format="lfm25",
+        )
+        issues = validate_tool_format(info, "lfm2")
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert any(i.code == "MISSING_TOOL_LIST_MARKERS" for i in warnings)
+
+    def test_structured_auto_fixable(self):
+        info = ToolFormatInfo(
+            has_tool_calls=True,
+            has_structured_tool_calls=True,
+            detected_format="structured",
+        )
+        issues = validate_tool_format(info, "lfm2")
+        assert any(i.code == "STRUCTURED_TOOL_CALLS" and i.auto_fixable for i in issues)
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) == 0
+
+    def test_foreign_errors(self):
+        info = ToolFormatInfo(
+            has_tool_calls=True,
+            has_foreign_markers=True,
+            foreign_markers_found=["<tool_call>", "</tool_call>"],
+            detected_format="foreign",
+        )
+        issues = validate_tool_format(info, "lfm2")
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) == 1
+        assert errors[0].code == "FOREIGN_MARKERS"
+        assert not errors[0].auto_fixable
+
+    def test_prebaked_response_info(self):
+        info = ToolFormatInfo(
+            has_tool_calls=True,
+            has_tool_call_markers=True,
+            has_tool_response_markers=True,
+            detected_format="lfm25",
+        )
+        issues = validate_tool_format(info, "lfm25")
+        assert any(i.code == "PREBAKED_TOOL_RESPONSE" for i in issues)
+
+
+# === Pythonic conversion ===
+
+
+class TestToolCallsToPythonic:
+    def test_simple(self):
+        tc = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": {"location": "Boston"},
+                },
+            }
+        ]
+        result = tool_calls_to_pythonic(tc)
+        assert (
+            result
+            == '<|tool_call_start|>[get_weather(location="Boston")]<|tool_call_end|>'
+        )
+
+    def test_multiple_args(self):
+        tc = [
+            {
+                "type": "function",
+                "function": {"name": "f", "arguments": {"a": "x", "b": 42}},
+            }
+        ]
+        result = tool_calls_to_pythonic(tc)
+        assert result == '<|tool_call_start|>[f(a="x", b=42)]<|tool_call_end|>'
+
+    def test_multiple_calls(self):
+        tc = [
+            {"type": "function", "function": {"name": "f1", "arguments": {"a": 1}}},
+            {"type": "function", "function": {"name": "f2", "arguments": {"b": "y"}}},
+        ]
+        result = tool_calls_to_pythonic(tc)
+        assert result == '<|tool_call_start|>[f1(a=1), f2(b="y")]<|tool_call_end|>'
+
+    def test_no_args(self):
+        tc = [{"type": "function", "function": {"name": "get_time", "arguments": {}}}]
+        result = tool_calls_to_pythonic(tc)
+        assert result == "<|tool_call_start|>[get_time()]<|tool_call_end|>"
+
+    def test_string_arguments(self):
+        tc = [
+            {
+                "type": "function",
+                "function": {"name": "f", "arguments": '{"x": "hello"}'},
+            }
+        ]
+        result = tool_calls_to_pythonic(tc)
+        assert result == '<|tool_call_start|>[f(x="hello")]<|tool_call_end|>'
+
+    def test_bool_arg(self):
+        tc = [
+            {"type": "function", "function": {"name": "f", "arguments": {"flag": True}}}
+        ]
+        result = tool_calls_to_pythonic(tc)
+        assert result == "<|tool_call_start|>[f(flag=True)]<|tool_call_end|>"
+
+
+# === Edge cases the current converter mishandles ===
+# Invariant: converter output must be valid Python (parseable by ast.parse).
+
+
+class TestToolCallsToPythonicEdgeCases:
+    @staticmethod
+    def _assert_parseable_python(result: str):
+        import ast
+
+        inner = result.replace("<|tool_call_start|>", "").replace(
+            "<|tool_call_end|>", ""
+        )
+        ast.parse(inner, mode="eval")
+
+    def test_string_with_embedded_double_quote(self):
+        # String arg containing `"` (e.g. a quoted search query) must be
+        # escaped so the output is still valid Python.
+        tc = [
+            {
+                "type": "function",
+                "function": {"name": "f", "arguments": {"msg": 'he said "hi"'}},
+            }
+        ]
+        result = tool_calls_to_pythonic(tc)
+        self._assert_parseable_python(result)
+
+    def test_string_with_newline(self):
+        # String arg containing `\n` (e.g. a multi-line email body) must be
+        # escaped; a raw newline inside `"..."` is an unterminated literal.
+        tc = [
+            {
+                "type": "function",
+                "function": {"name": "f", "arguments": {"body": "line1\nline2"}},
+            }
+        ]
+        result = tool_calls_to_pythonic(tc)
+        self._assert_parseable_python(result)
+
+    def test_string_with_backslash(self):
+        # String arg containing `\` (e.g. a Windows path) must be escaped;
+        # otherwise `\U` etc. is parsed as a Python unicode escape.
+        tc = [
+            {
+                "type": "function",
+                "function": {"name": "f", "arguments": {"path": r"C:\Users\x"}},
+            }
+        ]
+        result = tool_calls_to_pythonic(tc)
+        self._assert_parseable_python(result)
+
+    def test_non_dict_arguments_does_not_crash(self):
+        # Malformed `arguments` (list instead of dict) should be skipped
+        # with a warning, not crash the Ray worker with AttributeError.
+        tc = [{"type": "function", "function": {"name": "f", "arguments": [1, 2, 3]}}]
+        result = tool_calls_to_pythonic(tc)
+        assert isinstance(result, str)
+        assert result.startswith("<|tool_call_start|>")
+        assert result.endswith("<|tool_call_end|>")
+
+    def test_nested_list_of_strings_is_parseable(self):
+        # Nested list args must produce valid Python; quote style is left
+        # unconstrained since both `['a']` and `["a"]` are legal.
+        tc = [
+            {
+                "type": "function",
+                "function": {"name": "f", "arguments": {"tags": ["a", "b"]}},
+            }
+        ]
+        result = tool_calls_to_pythonic(tc)
+        self._assert_parseable_python(result)
+
+    def test_nested_dict_string_values_is_parseable(self):
+        # Nested dict args must produce valid Python; quote style unconstrained.
+        tc = [
+            {
+                "type": "function",
+                "function": {"name": "f", "arguments": {"opts": {"name": "foo"}}},
+            }
+        ]
+        result = tool_calls_to_pythonic(tc)
+        self._assert_parseable_python(result)
+
+
+# === Normalization ===
+
+
+class TestNormalizeToolFormat:
+    def test_strip_tool_list_for_lfm25(self):
+        row = {
+            "conversations": [
+                {
+                    "role": "system",
+                    "content": '<|tool_list_start|>[{"name": "f"}]<|tool_list_end|>\nYou help.',
+                },
+                {"role": "user", "content": "hi"},
+            ]
+        }
+        result = normalize_tool_format(row, "lfm25")
+        system_content = result["conversations"][0]["content"]
+        assert "<|tool_list_start|>" not in system_content
+        assert "<|tool_list_end|>" not in system_content
+        assert '{"name": "f"}' in system_content
+
+    def test_keep_tool_list_for_lfm2(self):
+        row = {
+            "conversations": [
+                {
+                    "role": "system",
+                    "content": '<|tool_list_start|>[{"name": "f"}]<|tool_list_end|>',
+                },
+                {"role": "user", "content": "hi"},
+            ]
+        }
+        result = normalize_tool_format(row, "lfm2")
+        system_content = result["conversations"][0]["content"]
+        assert "<|tool_list_start|>" in system_content
+
+    def test_strip_tool_response_markers(self):
+        row = {
+            "messages": [
+                {
+                    "role": "tool",
+                    "content": '<|tool_response_start|>{"r": 1}<|tool_response_end|>',
+                },
+            ]
+        }
+        result = normalize_tool_format(row, "lfm2")
+        assert result["messages"][0]["content"] == '{"r": 1}'
+
+    def test_strip_tool_response_for_lfm25_too(self):
+        row = {
+            "messages": [
+                {
+                    "role": "tool",
+                    "content": '<|tool_response_start|>{"r": 1}<|tool_response_end|>',
+                },
+            ]
+        }
+        result = normalize_tool_format(row, "lfm25")
+        assert result["messages"][0]["content"] == '{"r": 1}'
+
+    def test_convert_structured_tool_calls(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": {"location": "SF"},
+                            },
+                        },
+                    ],
+                },
+            ]
+        }
+        result = normalize_tool_format(row, "lfm2")
+        assistant_msg = result["messages"][1]
+        assert "<|tool_call_start|>" in assistant_msg["content"]
+        assert 'get_weather(location="SF")' in assistant_msg["content"]
+        assert "tool_calls" not in assistant_msg
+
+    def test_no_modification_when_clean(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ]
+        }
+        result = normalize_tool_format(row, "lfm2")
+        assert result is row  # Same object, no copy
+
+    def test_preserves_column_name(self):
+        row_conv = {
+            "conversations": [
+                {"role": "system", "content": "<|tool_list_start|>x<|tool_list_end|>"}
+            ]
+        }
+        result = normalize_tool_format(row_conv, "lfm25")
+        assert "conversations" in result
+        assert "messages" not in result
+
+    def test_no_double_wrapping_after_normalize_and_template(self):
+        """After normalization, LFM2 template should produce exactly one tool_response wrapper."""
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": "<|tool_call_start|>[f()]<|tool_call_end|>",
+                },
+                {
+                    "role": "tool",
+                    "content": '<|tool_response_start|>{"r": 1}<|tool_response_end|>',
+                },
+            ]
+        }
+        result = normalize_tool_format(row, "lfm2")
+        # After normalization, tool content should be clean
+        assert result["messages"][2]["content"] == '{"r": 1}'

--- a/tests/test_trainer_mixins.py
+++ b/tests/test_trainer_mixins.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+import pytest
+from datasets import Dataset
+
+from leap_finetune.training.dpo import LFMDPOTrainer
+from leap_finetune.training.utils.trainer_lifecycle import run_training_safely
+
+
+class FailingTrainer:
+    def __init__(self, *, global_step=0, max_steps=-1, epoch=None, num_train_epochs=1):
+        self.state = SimpleNamespace(global_step=global_step, epoch=epoch)
+        self.args = SimpleNamespace(
+            max_steps=max_steps, num_train_epochs=num_train_epochs
+        )
+
+    def train(self, **kwargs):
+        raise RuntimeError("NCCL error during cleanup")
+
+
+def test_run_training_safely_suppresses_cleanup_error_after_max_steps(caplog):
+    trainer = FailingTrainer(global_step=10, max_steps=10)
+
+    run_training_safely(trainer)
+
+    assert "Training completed but hit distributed communication error" in caplog.text
+
+
+def test_run_training_safely_raises_distributed_error_before_max_steps():
+    trainer = FailingTrainer(global_step=9, max_steps=10)
+
+    with pytest.raises(RuntimeError, match="NCCL error"):
+        run_training_safely(trainer)
+
+
+def test_run_training_safely_suppresses_cleanup_error_after_epoch_target(caplog):
+    trainer = FailingTrainer(
+        global_step=10, max_steps=-1, epoch=1.0, num_train_epochs=1
+    )
+
+    run_training_safely(trainer)
+
+    assert "Training completed but hit distributed communication error" in caplog.text
+
+
+def test_lfm_dpo_trainer_skips_prepare_dataset():
+    dummy = Dataset.from_dict({"a": [1, 2, 3]})
+
+    result = LFMDPOTrainer._prepare_dataset(None, dummy)
+
+    assert result is dummy

--- a/tests/test_trainer_mixins.py
+++ b/tests/test_trainer_mixins.py
@@ -5,6 +5,9 @@ from datasets import Dataset
 
 from leap_finetune.training.dpo import LFMDPOTrainer
 from leap_finetune.training.utils.trainer_lifecycle import run_training_safely
+from leap_finetune.training.utils.trainer_mixins import (
+    validate_manual_sharded_training_args,
+)
 
 
 class FailingTrainer:
@@ -49,3 +52,12 @@ def test_lfm_dpo_trainer_skips_prepare_dataset():
     result = LFMDPOTrainer._prepare_dataset(None, dummy)
 
     assert result is dummy
+
+
+def test_validate_manual_sharded_training_args_accepts_raw_checkpoint_format():
+    validate_manual_sharded_training_args({}, checkpoint_format="both")
+
+
+def test_validate_manual_sharded_training_args_rejects_raw_checkpoint_format():
+    with pytest.raises(ValueError, match="manual_sharded_checkpoint_format"):
+        validate_manual_sharded_training_args({}, checkpoint_format="invalid")

--- a/tests/test_training_configs.py
+++ b/tests/test_training_configs.py
@@ -1,0 +1,267 @@
+import pytest
+
+from leap_finetune.config.parser import parse_job_config
+
+from conftest import BASE_DPO_DATASET, BASE_SFT_DATASET, BASE_VLM_DATASET, write_config
+
+pytestmark = pytest.mark.configs
+
+
+# === Config pipeline integrity ===
+
+
+class TestConfigPipelineIntegrity:
+    def test_sft_lr_survives_pipeline(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT", "learning_rate": 2e-5},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        from leap_finetune.training.default_configs.sft_configs import SFT_EXCLUDED_KEYS
+
+        excluded = SFT_EXCLUDED_KEYS | {"leap_run_name_template"}
+        filtered = {k: v for k, v in d["training_config"].items() if k not in excluded}
+        assert filtered["learning_rate"] == 2e-5
+
+    def test_dpo_beta_survives_pipeline(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "dpo",
+            "dataset": BASE_DPO_DATASET,
+            "training_config": {"extends": "DEFAULT_DPO", "beta": 0.3},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        excluded = {"training_type", "wandb_logging", "leap_run_name_template"}
+        filtered = {k: v for k, v in d["training_config"].items() if k not in excluded}
+        assert filtered["beta"] == 0.3
+
+    def test_vlm_lr_survives_pipeline(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "vlm_sft",
+            "dataset": BASE_VLM_DATASET,
+            "training_config": {"extends": "DEFAULT_VLM_SFT", "learning_rate": 1e-5},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        from leap_finetune.training.default_configs.vlm_sft_configs import (
+            VLM_SFT_EXCLUDED_KEYS,
+        )
+
+        excluded = VLM_SFT_EXCLUDED_KEYS | {"leap_run_name_template"}
+        filtered = {k: v for k, v in d["training_config"].items() if k not in excluded}
+        assert filtered["learning_rate"] == 1e-5
+
+    def test_sft_filtering_removes_only_excluded_keys(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT", "learning_rate": 2e-5},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        from leap_finetune.training.default_configs.sft_configs import SFT_EXCLUDED_KEYS
+
+        excluded = SFT_EXCLUDED_KEYS | {"leap_run_name_template"}
+        filtered = {k: v for k, v in d["training_config"].items() if k not in excluded}
+        for key in SFT_EXCLUDED_KEYS:
+            assert key not in filtered
+        assert "leap_run_name_template" not in filtered
+        assert "learning_rate" in filtered
+        assert "output_dir" in filtered
+        assert "deepspeed" in filtered
+
+    def test_dpo_filtering_removes_only_excluded_keys(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "dpo",
+            "dataset": BASE_DPO_DATASET,
+            "training_config": {"extends": "DEFAULT_DPO"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        excluded = {"training_type", "wandb_logging", "leap_run_name_template"}
+        filtered = {k: v for k, v in d["training_config"].items() if k not in excluded}
+        assert "training_type" not in filtered
+        assert "learning_rate" in filtered
+        assert "beta" in filtered
+        assert "deepspeed" in filtered
+
+    def test_vlm_filtering_removes_only_excluded_keys(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "vlm_sft",
+            "dataset": BASE_VLM_DATASET,
+            "training_config": {"extends": "DEFAULT_VLM_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        from leap_finetune.training.default_configs.vlm_sft_configs import (
+            VLM_SFT_EXCLUDED_KEYS,
+        )
+
+        excluded = VLM_SFT_EXCLUDED_KEYS | {"leap_run_name_template"}
+        filtered = {k: v for k, v in d["training_config"].items() if k not in excluded}
+        for key in VLM_SFT_EXCLUDED_KEYS:
+            assert key not in filtered
+        assert "learning_rate" in filtered
+        assert "deepspeed" in filtered
+
+    def test_fsdp_replaces_deepspeed_for_moe_no_peft(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-8B-A1B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "MOE_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        from leap_finetune.distribution.distributed_configs import (
+            MOE_FSDP_CONFIG,
+        )
+        from leap_finetune.training.default_configs.sft_configs import SFT_EXCLUDED_KEYS
+        from leap_finetune.checkpointing.model_info import is_moe_model_from_name
+
+        is_moe = is_moe_model_from_name(d["model_name"])
+        use_fsdp = is_moe and d["peft_config"] is None
+        assert use_fsdp
+
+        excluded = SFT_EXCLUDED_KEYS | {"leap_run_name_template", "deepspeed"}
+        filtered = {k: v for k, v in d["training_config"].items() if k not in excluded}
+        assert "deepspeed" not in filtered
+
+        config_kwargs = {**filtered}
+        config_kwargs["fsdp"] = MOE_FSDP_CONFIG["fsdp"]
+        config_kwargs["fsdp_config"] = MOE_FSDP_CONFIG["fsdp_config"]
+        assert "fsdp" in config_kwargs
+        assert "shard_grad_op" in config_kwargs["fsdp"]
+
+    def test_full_finetune_no_peft_config(self, tmp_path):
+        config = {
+            "project_name": "test",
+            "model_name": "LFM2-1.2B",
+            "training_type": "sft",
+            "dataset": BASE_SFT_DATASET,
+            "training_config": {"extends": "DEFAULT_SFT"},
+            "peft_config": {"use_peft": False},
+        }
+        job = parse_job_config(write_config(config, tmp_path))
+        d = job.to_dict()
+        assert d["peft_config"] is None
+
+
+# === DeepSpeed config structure ===
+
+
+class TestDeepSpeedConfigStructure:
+    def test_sft_deepspeed_has_optimizer(self):
+        from leap_finetune.training.default_configs.sft_configs import DEEPSPEED_CONFIG
+
+        assert "optimizer" in DEEPSPEED_CONFIG
+        assert DEEPSPEED_CONFIG["optimizer"]["type"] == "AdamW"
+
+    def test_dpo_deepspeed_has_no_optimizer(self):
+        from leap_finetune.training.default_configs.dpo_configs import DEEPSPEED_CONFIG
+
+        assert "optimizer" not in DEEPSPEED_CONFIG
+
+    def test_vlm_deepspeed_has_no_optimizer(self):
+        from leap_finetune.training.default_configs.vlm_sft_configs import (
+            DEEPSPEED_CONFIG,
+        )
+
+        assert "optimizer" not in DEEPSPEED_CONFIG
+
+    def test_moe_sft_deepspeed_has_optimizer(self):
+        from leap_finetune.training.default_configs.sft_configs import (
+            MOE_DEEPSPEED_CONFIG,
+        )
+
+        assert "optimizer" in MOE_DEEPSPEED_CONFIG
+        assert MOE_DEEPSPEED_CONFIG["optimizer"]["type"] == "AdamW"
+
+    def test_moe_dpo_deepspeed_has_no_optimizer(self):
+        from leap_finetune.training.default_configs.dpo_configs import (
+            MOE_DEEPSPEED_CONFIG,
+        )
+
+        assert "optimizer" not in MOE_DEEPSPEED_CONFIG
+
+    def test_sft_deepspeed_zero_stage_2(self):
+        from leap_finetune.training.default_configs.sft_configs import DEEPSPEED_CONFIG
+
+        assert DEEPSPEED_CONFIG["zero_optimization"]["stage"] == 2
+
+    def test_moe_deepspeed_zero_stage_0(self):
+        from leap_finetune.training.default_configs.sft_configs import (
+            MOE_DEEPSPEED_CONFIG,
+        )
+
+        assert MOE_DEEPSPEED_CONFIG["zero_optimization"]["stage"] == 0
+
+
+# === MoE detection ===
+
+
+class TestMoEDetection:
+    def test_dense_not_moe(self):
+        from leap_finetune.checkpointing.model_info import is_moe_model_from_name
+
+        assert not is_moe_model_from_name("LFM2-1.2B")
+
+    def test_8b_a1b_is_moe(self):
+        from leap_finetune.checkpointing.model_info import is_moe_model_from_name
+
+        assert is_moe_model_from_name("LFM2-8B-A1B")
+
+    def test_case_insensitive(self):
+        from leap_finetune.checkpointing.model_info import is_moe_model_from_name
+
+        assert is_moe_model_from_name("lfm2-8b-a1b")
+
+    def test_moe_string_in_name(self):
+        from leap_finetune.checkpointing.model_info import is_moe_model_from_name
+
+        assert is_moe_model_from_name("some-moe-model")
+
+
+# === FSDP config ===
+
+
+class TestFSDPConfig:
+    def test_moe_fsdp_wraps_correct_layer(self):
+        from leap_finetune.distribution.distributed_configs import (
+            MOE_FSDP_CONFIG,
+        )
+
+        assert (
+            MOE_FSDP_CONFIG["fsdp_config"]["transformer_layer_cls_to_wrap"]
+            == "Lfm2MoeDecoderLayer"
+        )
+
+    def test_moe_fsdp_shard_grad_op(self):
+        from leap_finetune.distribution.distributed_configs import (
+            MOE_FSDP_CONFIG,
+        )
+
+        assert "shard_grad_op" in MOE_FSDP_CONFIG["fsdp"]
+        assert "auto_wrap" in MOE_FSDP_CONFIG["fsdp"]

--- a/tests/test_training_configs.py
+++ b/tests/test_training_configs.py
@@ -1,10 +1,17 @@
 import pytest
 
-from leap_finetune.config.parser import parse_job_config
+from leap_finetune.config.parser import (
+    materialize_job_config,
+    parse_job_config as _parse_job_config,
+)
 
 from conftest import BASE_DPO_DATASET, BASE_SFT_DATASET, BASE_VLM_DATASET, write_config
 
 pytestmark = pytest.mark.configs
+
+
+def parse_job_config(config_input):
+    return materialize_job_config(_parse_job_config(config_input))
 
 
 # === Config pipeline integrity ===
@@ -174,49 +181,43 @@ class TestConfigPipelineIntegrity:
 
 class TestDeepSpeedConfigStructure:
     def test_sft_deepspeed_has_optimizer(self):
-        from leap_finetune.training.default_configs.sft_configs import DEEPSPEED_CONFIG
+        from leap_finetune.training.default_configs.sft_configs import DEFAULT_SFT
 
-        assert "optimizer" in DEEPSPEED_CONFIG
-        assert DEEPSPEED_CONFIG["optimizer"]["type"] == "AdamW"
+        cfg = DEFAULT_SFT["deepspeed"]
+        assert "optimizer" in cfg
+        assert cfg["optimizer"]["type"] == "AdamW"
 
     def test_dpo_deepspeed_has_no_optimizer(self):
-        from leap_finetune.training.default_configs.dpo_configs import DEEPSPEED_CONFIG
+        from leap_finetune.training.default_configs.dpo_configs import DEFAULT_DPO
 
-        assert "optimizer" not in DEEPSPEED_CONFIG
+        assert "optimizer" not in DEFAULT_DPO["deepspeed"]
 
     def test_vlm_deepspeed_has_no_optimizer(self):
         from leap_finetune.training.default_configs.vlm_sft_configs import (
-            DEEPSPEED_CONFIG,
+            DEFAULT_VLM_SFT,
         )
 
-        assert "optimizer" not in DEEPSPEED_CONFIG
+        assert "optimizer" not in DEFAULT_VLM_SFT["deepspeed"]
 
-    def test_moe_sft_deepspeed_has_optimizer(self):
-        from leap_finetune.training.default_configs.sft_configs import (
-            MOE_DEEPSPEED_CONFIG,
-        )
+    def test_moe_sft_deepspeed_has_no_optimizer(self):
+        from leap_finetune.training.default_configs.sft_configs import MOE_SFT
 
-        assert "optimizer" in MOE_DEEPSPEED_CONFIG
-        assert MOE_DEEPSPEED_CONFIG["optimizer"]["type"] == "AdamW"
+        assert "optimizer" not in MOE_SFT["deepspeed"]
 
     def test_moe_dpo_deepspeed_has_no_optimizer(self):
-        from leap_finetune.training.default_configs.dpo_configs import (
-            MOE_DEEPSPEED_CONFIG,
-        )
+        from leap_finetune.training.default_configs.dpo_configs import MOE_DPO
 
-        assert "optimizer" not in MOE_DEEPSPEED_CONFIG
+        assert "optimizer" not in MOE_DPO["deepspeed"]
 
     def test_sft_deepspeed_zero_stage_2(self):
-        from leap_finetune.training.default_configs.sft_configs import DEEPSPEED_CONFIG
+        from leap_finetune.training.default_configs.sft_configs import DEFAULT_SFT
 
-        assert DEEPSPEED_CONFIG["zero_optimization"]["stage"] == 2
+        assert DEFAULT_SFT["deepspeed"]["zero_optimization"]["stage"] == 2
 
     def test_moe_deepspeed_zero_stage_0(self):
-        from leap_finetune.training.default_configs.sft_configs import (
-            MOE_DEEPSPEED_CONFIG,
-        )
+        from leap_finetune.training.default_configs.sft_configs import MOE_SFT
 
-        assert MOE_DEEPSPEED_CONFIG["zero_optimization"]["stage"] == 0
+        assert MOE_SFT["deepspeed"]["zero_optimization"]["stage"] == 0
 
 
 # === MoE detection ===

--- a/tests/test_vllm_server.py
+++ b/tests/test_vllm_server.py
@@ -1,0 +1,242 @@
+import pytest
+
+from leap_finetune.distribution.vllm_server import (
+    plan_gpu_split,
+    resolve_vllm_rollout_plan,
+)
+
+pytestmark = pytest.mark.configs
+
+
+# === vLLM server resource planning ===
+
+
+class TestVLLMRolloutResourcePlan:
+    def test_colocate_uses_all_gpus_without_local_server(self):
+        plan = resolve_vllm_rollout_plan(
+            4, {}, vllm_mode="colocate", is_multi_node=False
+        )
+        assert plan.server_gpu_ids == []
+        assert plan.training_gpu_ids == [0, 1, 2, 3]
+        assert plan.num_training_workers == 4
+        assert not plan.launches_local_server
+
+    def test_colocate_ignores_server_split_block(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"server_gpus": 1, "training_gpus": 2},
+            vllm_mode="colocate",
+            is_multi_node=True,
+        )
+        assert plan.server_gpu_ids == []
+        assert plan.training_gpu_ids == [0, 1, 2, 3]
+        assert plan.num_training_workers == 4
+
+    def test_colocate_can_reserve_local_judge_gpu(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {},
+            vllm_mode="colocate",
+            is_multi_node=False,
+            reserve_judge=True,
+        )
+        assert plan.server_gpu_ids == []
+        assert plan.judge_gpu_ids == [0]
+        assert plan.training_gpu_ids == [1, 2, 3]
+        assert plan.judge_cuda_visible_devices == "0"
+        assert plan.training_cuda_visible_devices == "1,2,3"
+        assert plan.launches_local_judge
+
+    def test_server_gpu_count_keeps_server_out_of_ray(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"server_gpus": 1},
+            vllm_mode="server",
+            is_multi_node=False,
+        )
+        assert plan.server_gpu_ids == [0]
+        assert plan.judge_gpu_ids == []
+        assert plan.training_gpu_ids == [1, 2, 3]
+        assert plan.server_cuda_visible_devices == "0"
+        assert plan.training_cuda_visible_devices == "1,2,3"
+        assert plan.num_training_workers == 3
+        assert plan.resources_per_worker == {"GPU": 1.0}
+        assert plan.uses_custom_training_visibility
+
+    def test_existing_cuda_visible_devices_mapping_is_preserved(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
+
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"server_gpus": 1},
+            vllm_mode="server",
+            is_multi_node=False,
+        )
+
+        assert plan.server_gpu_ids == [0]
+        assert plan.training_gpu_ids == [1, 2, 3]
+        assert plan.server_cuda_visible_devices == "4"
+        assert plan.training_cuda_visible_devices == "5,6,7"
+
+    def test_training_gpu_count_can_leave_extra_gpus_idle(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"server_gpus": 1, "training_gpus": 2},
+            vllm_mode="server",
+            is_multi_node=False,
+        )
+        assert plan.server_gpu_ids == [0]
+        assert plan.training_gpu_ids == [1, 2]
+        assert plan.num_training_workers == 2
+
+    def test_training_gpu_count_infers_remaining_server_gpus(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"training_gpus": 2},
+            vllm_mode="server",
+            is_multi_node=False,
+        )
+
+        assert plan.server_gpu_ids == [0, 1]
+        assert plan.training_gpu_ids == [2, 3]
+        assert plan.server_cuda_visible_devices == "0,1"
+        assert plan.training_cuda_visible_devices == "2,3"
+        assert plan.num_training_workers == 2
+        assert plan.launches_local_server
+
+    def test_server_mode_reserves_judge_between_rollout_and_training(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"server_gpus": 1, "judge_gpus": 1},
+            vllm_mode="server",
+            is_multi_node=False,
+            reserve_judge=True,
+        )
+
+        assert plan.server_gpu_ids == [0]
+        assert plan.judge_gpu_ids == [1]
+        assert plan.training_gpu_ids == [2, 3]
+        assert plan.server_cuda_visible_devices == "0"
+        assert plan.judge_cuda_visible_devices == "1"
+        assert plan.training_cuda_visible_devices == "2,3"
+
+    def test_training_gpu_count_infers_server_after_judge_reservation(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"training_gpus": 2},
+            vllm_mode="server",
+            is_multi_node=False,
+            reserve_judge=True,
+        )
+
+        assert plan.server_gpu_ids == [0]
+        assert plan.judge_gpu_ids == [1]
+        assert plan.training_gpu_ids == [2, 3]
+
+    def test_training_gpu_count_must_leave_a_server_gpu_when_inferred(self):
+        with pytest.raises(ValueError, match="local vLLM server"):
+            resolve_vllm_rollout_plan(
+                4,
+                {"training_gpus": 4},
+                vllm_mode="server",
+                is_multi_node=False,
+            )
+
+    def test_server_gpus_zero_keeps_external_server_mode_explicit(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"server_gpus": 0, "training_gpus": 2},
+            vllm_mode="server",
+            is_multi_node=False,
+        )
+
+        assert not plan.launches_local_server
+        assert plan.server_gpu_ids == []
+        assert plan.training_gpu_ids == [0, 1]
+        assert plan.training_cuda_visible_devices == "0,1"
+        assert plan.num_training_workers == 2
+
+    def test_judge_gpus_are_ignored_without_local_judge_reward(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"judge_gpus": 1},
+            vllm_mode="colocate",
+            is_multi_node=False,
+            reserve_judge=False,
+        )
+
+        assert not plan.launches_local_judge
+        assert plan.training_gpu_ids == [0, 1, 2, 3]
+
+    def test_dedicated_gpus_legacy_alias_still_works(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"dedicated_gpus": 2},
+            vllm_mode="server",
+            is_multi_node=False,
+        )
+        assert plan.server_gpu_ids == [0, 1]
+        assert plan.training_gpu_ids == [2, 3]
+        assert plan.num_training_workers == 2
+
+    def test_too_many_requested_gpus_raises(self):
+        with pytest.raises(ValueError, match="requests"):
+            resolve_vllm_rollout_plan(
+                4,
+                {"server_gpus": 2, "training_gpus": 3},
+                vllm_mode="server",
+                is_multi_node=False,
+            )
+
+    def test_training_gpu_count_must_leave_a_training_gpu(self):
+        with pytest.raises(ValueError, match="training_gpus"):
+            resolve_vllm_rollout_plan(
+                2,
+                {"server_gpus": 2},
+                vllm_mode="server",
+                is_multi_node=False,
+            )
+
+    def test_dedicated_local_server_is_single_node_only(self):
+        with pytest.raises(NotImplementedError, match="single-node"):
+            resolve_vllm_rollout_plan(
+                4,
+                {"dedicated_gpus": 1},
+                vllm_mode="server",
+                is_multi_node=True,
+            )
+
+    def test_training_gpu_count_is_single_node_only(self):
+        with pytest.raises(NotImplementedError, match="single-node"):
+            resolve_vllm_rollout_plan(
+                4,
+                {"training_gpus": 2},
+                vllm_mode="server",
+                is_multi_node=True,
+            )
+
+    def test_external_multi_node_server_without_local_partitioning(self):
+        plan = resolve_vllm_rollout_plan(
+            4,
+            {"tensor_parallel_size": 1},
+            vllm_mode="server",
+            is_multi_node=True,
+        )
+
+        assert not plan.launches_local_server
+        assert not plan.launches_local_judge
+        assert plan.training_gpu_ids == [0, 1, 2, 3]
+        assert not plan.uses_custom_training_visibility
+
+    def test_local_judge_partitioning_is_single_node_only(self):
+        with pytest.raises(NotImplementedError, match="single-node"):
+            resolve_vllm_rollout_plan(
+                4,
+                {},
+                vllm_mode="colocate",
+                is_multi_node=True,
+                reserve_judge=True,
+            )
+
+    def test_legacy_plan_gpu_split_uses_new_planner(self):
+        assert plan_gpu_split(4, {"dedicated_gpus": 2}) == ([0, 1], [2, 3])

--- a/tests/test_vlm_e2e.py
+++ b/tests/test_vlm_e2e.py
@@ -1,0 +1,82 @@
+import pytest
+
+from conftest import (
+    assert_checkpoints_exist,
+    assert_training_result,
+    requires_gpu,
+    run_e2e_training,
+)
+
+pytestmark = pytest.mark.vlm
+
+FIXTURES = __import__("pathlib").Path(__file__).parent / "fixtures"
+
+
+# === VLM SFT with LoRA ===
+
+
+class TestVLMLoRA:
+    @requires_gpu
+    def test_training_completes_and_learns(self, e2e_output_dir):
+        config_path = str(FIXTURES / "e2e_vlm_lora.yaml")
+        result = run_e2e_training(config_path, e2e_output_dir)
+        assert_training_result(result)
+
+    @requires_gpu
+    def test_vlm_custom_optimizer_structure(self):
+        """Verify LFMVLMTrainer creates per-component LR param groups."""
+        import torch
+        from transformers import TrainingArguments
+
+        from leap_finetune.checkpointing.model_loading import load_vlm_model
+        from leap_finetune.training.default_configs.vlm_sft_configs import (
+            DEFAULT_LR_MULTIPLIERS,
+        )
+        from leap_finetune.training.vlm_sft import LFMVLMTrainer
+
+        model, processor = load_vlm_model("LFM2-VL-1.6B")
+        args = TrainingArguments(
+            output_dir="/tmp/test_vlm_opt",
+            learning_rate=1e-4,
+            per_device_train_batch_size=1,
+            report_to="none",
+            max_steps=1,
+        )
+        trainer = LFMVLMTrainer(
+            lr_multipliers=DEFAULT_LR_MULTIPLIERS,
+            model=model,
+            processing_class=processor,
+            args=args,
+        )
+        optimizer = trainer.create_optimizer()
+
+        assert isinstance(optimizer, torch.optim.AdamW)
+
+        # Should have param groups for each prefix + possibly ungrouped
+        groups = optimizer.param_groups
+        assert len(groups) >= 2, f"Expected multiple param groups, got {len(groups)}"
+
+        # Find the vision_tower group (should have lr = base_lr * 0.1)
+        base_lr = args.learning_rate
+        vision_group = None
+        for g in groups:
+            if abs(g["lr"] - base_lr * 0.1) < 1e-10:
+                vision_group = g
+                break
+        assert vision_group is not None, (
+            f"No param group with vision tower LR ({base_lr * 0.1}). "
+            f"Groups have LRs: {[g['lr'] for g in groups]}"
+        )
+
+
+# === VLM SFT full fine-tune ===
+
+
+class TestVLMFull:
+    @requires_gpu
+    def test_training_completes_learns_and_checkpoints(self, e2e_output_dir):
+        config_path = str(FIXTURES / "e2e_vlm_full.yaml")
+        result = run_e2e_training(config_path, e2e_output_dir)
+        assert_training_result(result)
+
+        assert_checkpoints_exist(e2e_output_dir)


### PR DESCRIPTION
## Summary

This PR adds first-class MoE training support with an expert-parallel runtime, manual sharded checkpoint export, and a cleaned-up package structure rebased onto the current GRPO mainline.

Major changes:
- Add MoE SFT/DPO training paths with EP token dispatch, grouped expert compute, FSDP2 wrapping over the DP mesh, activation checkpointing, MoE metrics, and memory tracing.
- Add manual sharded checkpoint save/export support that can reconstruct HF-compatible checkpoints from FSDP2/EP runs.
- Reorganize runtime modules into clearer packages: `data_loading`, `training`, `checkpointing`, `distribution`, `config`, `cli`, and `rl`.
- Keep GRPO helpers in the reorganized layout: training loops under `training/`, rollout/reward/env helpers under `rl/`, and user reward examples under repo-root `rewards/`.
- Add Ray/Slurm distribution helpers, multinode Ray startup/teardown, and rank/data sharding protections.
- Include one standard MoE EP SFT example config alongside the other committed examples.
- Expand regression coverage for config parsing, data loading, MoE losses/runtime, rank groups, checkpoint metadata/export, GRPO integration, and trainer lifecycle behavior.

## Validation

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_config_parsing.py tests/test_grpo_config.py tests/test_grpo_data.py tests/test_rewards_loader.py tests/test_vllm_server.py tests/test_rl_env_adapter.py tests/test_load_models.py tests/test_ray_cluster_support.py tests/test_training_configs.py tests/test_moe_ep_runtime.py tests/test_moe_losses.py tests/test_moe_trainers.py tests/test_sft_loss_masks.py tests/test_trainer_mixins.py` -> `323 passed, 5 warnings in 52.33s`

## Notes

The GPU e2e tests remain marked/skipped in local CPU-style test runs. Recent Slurm validation runs covered the DP4/EP2 and DP4/EP4 save paths before this final cleanup pass.